### PR TITLE
Add rate limiting for API requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydub>=0.25.1",
     "pysrt>=1.1.2",
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.23.5",
     "silero-vad>=5.1.2",
     "soundfile>=0.13.1",
 ]

--- a/src/sub_tools/system/rate_limiter.py
+++ b/src/sub_tools/system/rate_limiter.py
@@ -1,0 +1,40 @@
+
+import asyncio
+import time
+
+class RateLimiter:
+    def __init__(self, rate_limit: float, period: float):
+        """
+        Initialize a rate limiter.
+
+        Args:
+            rate_limit: Maximum number of requests in the time
+            period: Time period in seconds
+        """
+        self.rate_limit = rate_limit
+        self.period = period
+        self.request_times = []
+        self.lock = asyncio.Lock()
+
+    async def acquire(self):
+        """Acquire permission to make a request, waiting if necessary."""
+        async with self.lock:
+            current_time = time.time()
+
+            # Remove timestamps older than the period
+            cutoff = current_time - self.period
+            self.request_times = [t for t in self.request_times if t > cutoff]
+
+            # If we've reached the limit, wait until the oldest request expires
+            if len(self.request_times) >= self.rate_limit:
+                wait_time = self.request_times[0] + self.period - current_time
+
+                if wait_time > 0:
+                    print(f"Rate limit reached. Waiting {wait_time:.2f} seconds...")
+                    await asyncio.sleep(wait_time)
+
+                    # Recalculate current time after waiting
+                    current_time = time.time()
+
+            # Add the current request timestamp
+            self.request_times.append(current_time)

--- a/src/sub_tools/transcribe.py
+++ b/src/sub_tools/transcribe.py
@@ -9,10 +9,10 @@ from .subtitles.validator import validate_subtitles, SubtitleValidationError
 from .system.directory import paths_with_offsets
 from .system.language import get_language_name
 from .system.logger import write_log
+from .system.rate_limiter import RateLimiter
 
 
-max_concurrent_tasks = 4
-semaphore = asyncio.Semaphore(max_concurrent_tasks)
+rate_limiter = RateLimiter(rate_limit=10, period=60)
 
 
 @dataclass
@@ -57,59 +57,60 @@ async def _transcribe_item(
     debug: bool,
     config: TranscribeConfig,
 ) -> None:
-    async with semaphore:
-        language = get_language_name(language_code)
-        file = None
+    language = get_language_name(language_code)
+    file = None
 
-        try:
-            file_path = f"{config.directory}/{audio_segment_path}"
-            file = await upload_file(api_key, file_path)
-            duration_ms = get_duration(file_path) * 1000
+    try:
+        file_path = f"{config.directory}/{audio_segment_path}"
+        file = await upload_file(api_key, file_path)
+        duration_ms = get_duration(file_path) * 1000
 
-            for attempt in range(retry):
-                print(f"Transcribe attempt {attempt + 1}/{retry} for audio at {offset} to {language}")
+        for attempt in range(retry):
+            print(f"Transcribe attempt {attempt + 1}/{retry} for audio at {offset} to {language}")
+
+            try:
+                # Apply rate limiting for the audio_to_subtitles call
+                await rate_limiter.acquire()
+                subtitles = await audio_to_subtitles(api_key, file, audio_segment_format, language)
 
                 try:
-                    subtitles = await audio_to_subtitles(api_key, file, audio_segment_format, language)
+                    validate_subtitles(subtitles, duration_ms)
 
-                    try:
-                        validate_subtitles(subtitles, duration_ms)
-
-                        if debug:
-                            write_log(f"{language_code}_{offset}", "Valid", language, offset, subtitles, directory=f"./{config.directory}")
-                        serialize_subtitles(subtitles, language_code, int(offset), config.directory)
-                        break  # Happy path
-
-                    except SubtitleValidationError as e:
-                        if debug:
-                            write_log(f"{language_code}_{offset}", "Invalid", e, language, offset, subtitles, directory=f"./{config.directory}")
-
-                        # Use consistent backoff strategy
-                        wait_time = min(2**attempt, 60)
-                        await asyncio.sleep(wait_time)
-
-                except RateLimitExceededError:
                     if debug:
-                        write_log(f"{language_code}_{offset}", "Rate Limit Exceeded", "API rate limit exceeded", language, offset, directory=f"./{config.directory}")
-                except ClientError as e:
-                    if debug:
-                        write_log(f"{language_code}_{offset}", "API Error", f"ClientError: {e}", language, offset, directory=f"./{config.directory}")
-                except Exception as e:
-                    if debug:
-                        write_log(f"{language_code}_{offset}", "Unexpected Error", f"Exception: {e}", language, offset, directory=f"./{config.directory}")
+                        write_log(f"{language_code}_{offset}", "Valid", language, offset, subtitles, directory=f"./{config.directory}")
+                    serialize_subtitles(subtitles, language_code, int(offset), config.directory)
+                    break  # Happy path
 
-                # Use consistent backoff strategy
-                wait_time = min(2**attempt, 60)
-                await asyncio.sleep(wait_time)
-
-        except Exception as e:
-            if debug:
-                print(f"Error in transcription process: {str(e)}")
-
-        finally:
-            if file:
-                try:
-                    await delete_file(api_key, file)
-                except Exception as e:
+                except SubtitleValidationError as e:
                     if debug:
-                        print(f"Failed to delete file: {str(e)}")
+                        write_log(f"{language_code}_{offset}", "Invalid", e, language, offset, subtitles, directory=f"./{config.directory}")
+
+                    # Use consistent backoff strategy
+                    wait_time = min(2**attempt, 60)
+                    await asyncio.sleep(wait_time)
+
+            except RateLimitExceededError:
+                if debug:
+                    write_log(f"{language_code}_{offset}", "Rate Limit Exceeded", "API rate limit exceeded", language, offset, directory=f"./{config.directory}")
+            except ClientError as e:
+                if debug:
+                    write_log(f"{language_code}_{offset}", "API Error", f"ClientError: {e}", language, offset, directory=f"./{config.directory}")
+            except Exception as e:
+                if debug:
+                    write_log(f"{language_code}_{offset}", "Unexpected Error", f"Exception: {e}", language, offset, directory=f"./{config.directory}")
+
+            # Use consistent backoff strategy
+            wait_time = min(2**attempt, 60)
+            await asyncio.sleep(wait_time)
+
+    except Exception as e:
+        if debug:
+            print(f"Error in transcription process: {str(e)}")
+
+    finally:
+        if file:
+            try:
+                await delete_file(api_key, file)
+            except Exception as e:
+                if debug:
+                    print(f"Failed to delete file: {str(e)}")

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,113 @@
+import asyncio
+import time
+import pytest
+import pytest_asyncio
+
+from sub_tools.transcribe import RateLimiter
+
+
+@pytest_asyncio.fixture
+async def rate_limiter():
+    """Create a test rate limiter with 3 requests per second"""
+    return RateLimiter(rate_limit=3, period=1)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_init(rate_limiter):
+    """Test rate limiter initialization"""
+    assert rate_limiter.rate_limit == 3
+    assert rate_limiter.period == 1
+    assert rate_limiter.request_times == []
+    assert isinstance(rate_limiter.lock, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_acquire_under_limit(rate_limiter):
+    """Test rate limiter when under the request limit"""
+    start_time = time.time()
+    
+    # First 3 requests should be immediate
+    for _ in range(3):
+        await rate_limiter.acquire()
+    
+    duration = time.time() - start_time
+    # Should take almost no time - less than 0.1 seconds for all 3 requests
+    assert duration < 0.1
+    assert len(rate_limiter.request_times) == 3
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_acquire_at_limit():
+    """Test rate limiter when reaching the request limit"""
+    # Use a fresh limiter with known timing
+    limiter = RateLimiter(rate_limit=2, period=0.5)
+    
+    # First 2 requests should be immediate
+    await limiter.acquire()
+    await limiter.acquire()
+    
+    # Third request should wait
+    start_time = time.time()
+    await limiter.acquire()  # This should wait ~0.5 seconds
+    duration = time.time() - start_time
+    
+    # Should wait at least the period time (0.5 seconds)
+    assert duration >= 0.45  # Allow slight timing variance
+    assert len(limiter.request_times) == 3
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_request_expiration():
+    """Test that old request timestamps expire"""
+    limiter = RateLimiter(rate_limit=2, period=0.2)
+    
+    # Make 2 requests to hit the limit
+    await limiter.acquire()
+    await limiter.acquire()
+    assert len(limiter.request_times) == 2
+    
+    # Wait for requests to expire
+    await asyncio.sleep(0.3)  # Longer than the period
+    
+    # Request again - should clear old timestamps
+    await limiter.acquire()
+    assert len(limiter.request_times) == 1  # Only the new request remains
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests(rate_limiter):
+    """Test multiple tasks using the rate limiter concurrently"""
+    results = []
+    
+    async def worker(id):
+        start = time.time()
+        await rate_limiter.acquire()
+        results.append((id, time.time() - start))
+    
+    # Launch 5 tasks (with limit of 3 per second)
+    tasks = [asyncio.create_task(worker(i)) for i in range(5)]
+    await asyncio.gather(*tasks)
+    
+    # First 3 workers should have minimal wait time
+    assert results[0][1] < 0.1
+    assert results[1][1] < 0.1
+    assert results[2][1] < 0.1
+    
+    # Last 2 workers should have waited
+    assert results[3][1] >= 0.9  # Waited for first request to expire
+    assert results[4][1] >= 0.9  # Waited for second request to expire
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_stress():
+    """Stress test with rapid requests"""
+    limiter = RateLimiter(rate_limit=10, period=1)
+    start_time = time.time()
+    
+    # Make 30 requests (should take ~2 seconds with rate limit of 10/sec)
+    for i in range(30):
+        await limiter.acquire()
+    
+    duration = time.time() - start_time
+    # Should take at least 2 seconds for 30 requests at 10/sec
+    assert duration >= 2.0

--- a/uv.lock
+++ b/uv.lock
@@ -966,6 +966,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1046,6 +1058,7 @@ dependencies = [
     { name = "pydub" },
     { name = "pysrt" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "silero-vad" },
     { name = "soundfile" },
 ]
@@ -1058,6 +1071,7 @@ requires-dist = [
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "pysrt", specifier = ">=1.1.2" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.23.5" },
     { name = "silero-vad", specifier = ">=5.1.2" },
     { name = "soundfile", specifier = ">=0.13.1" },
 ]


### PR DESCRIPTION
- Implement RateLimiter class to limit requests to 10 per minute
- Apply rate limiting to audio_to_subtitles API calls
- Add unit tests for the rate limiter
- Add pytest-asyncio dependency for async tests

Resolves #11 