### PR TITLE
Fix easy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export GEMINI_API_KEY={your_api_key}
 sub-tools --hls-url https://example.com/hls/video.m3u8 --languages en es fr
 
 # Using MP3
-sub-tools --tasks segment transcribe combine --audio-file audio.mp3 -languages en es fr
+sub-tools --tasks segment transcribe combine --audio-file audio.mp3 --languages en es fr
 ```
 
 ### Build Docker

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -5,6 +5,15 @@ from importlib.metadata import version
 from .env_default import EnvDefault
 
 
+def _resolve_version() -> str:
+    """Return package version; fall back to a local dev string when unavailable."""
+    try:
+        return version("sub-tools")
+    except Exception:
+        # When running from source without installation, metadata lookup can fail.
+        return "0.0.0+local"
+
+
 def build_parser() -> ArgumentParser:
     parser = argparse.ArgumentParser(prog="sub-tools", description=None)
 
@@ -85,7 +94,7 @@ def build_parser() -> ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=version("sub-tools"),
+        version=_resolve_version(),
         help="Show program's version number and exit.",
     )
 


### PR DESCRIPTION
Fixes a typo in `README.md` where the `--languages` CLI option was incorrectly documented as `-languages` in the MP3 usage example.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f19b206-5917-4335-8be9-ca32acfdf3e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f19b206-5917-4335-8be9-ca32acfdf3e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

