### PR TITLE
feat: Improve LLM transcription instructions for complete audio coverage

### DIFF
--- a/src/sub_tools/intelligence/client.py
+++ b/src/sub_tools/intelligence/client.py
@@ -42,12 +42,20 @@ async def audio_to_subtitles(
        - A timestamp line
        - 1-2 lines of text
        - A blank line between entries.
-    5. The SRT file MUST cover the entire input audio file without missing any content.
+    5. ABSOLUTE REQUIREMENT - COMPLETE TRANSCRIPTION: You MUST transcribe EVERY SINGLE WORD and sound from the ENTIRE audio file from start to finish.
+       - Listen to the complete audio file and transcribe everything you hear.
+       - The first subtitle MUST start at or near 00:00:00,000 (the very beginning of the audio).
+       - The last subtitle MUST end at or very close to the actual end of the audio file.
+       - Do NOT stop transcribing early. Do NOT skip any portions of the audio.
+       - If you reach what seems like a natural stopping point but there is more audio, CONTINUE transcribing.
+       - Count: If the audio is X seconds long, your final subtitle timestamp should approach X seconds.
     6. The SRT file MUST be in the target language.
     7. Before returning the final SRT, re-check that:
        - All lines follow the SRT numbering and timestamp format strictly.
        - There are no overlaps, and each timestamp is valid and sequential.
        - There are no extraneous characters or missing commas for the timestamps.
+       - YOU HAVE TRANSCRIBED THE ENTIRE AUDIO FILE - verify the last timestamp is near the end of the audio duration.
+       - YOU HAVE NOT MISSED ANY CONTENT from beginning to end.
 
     Timing Guidelines:
     - Ensure no timestamp overlaps.


### PR DESCRIPTION
## Problem
When using LLM-based transcription, users often receive incomplete subtitles that don't cover the entire audio duration. The LLM stops transcribing early or skips portions of the audio.

## Solution
Enhanced the system instruction prompt in `audio_to_subtitles()` to be much more explicit and emphatic about transcribing the complete audio file:

### Changes to Requirement #5:
- Expanded from a single line to a detailed, emphatic section
- Added explicit instruction to transcribe "EVERY SINGLE WORD and sound"
- Specified that first subtitle must start at or near 00:00:00,000
- Specified that last subtitle must end at or very close to the actual audio end time
- Added explicit warnings: "Do NOT stop transcribing early" and "Do NOT skip any portions"
- Added instruction to CONTINUE even at natural stopping points if more audio remains
- Added cross-check guidance: "If audio is X seconds long, final timestamp should approach X seconds"

### Enhanced Requirement #7 (Validation):
- Added validation step to verify the last timestamp is near the end of audio duration
- Added validation to confirm NO CONTENT was missed from beginning to end

## Impact
This change makes the LLM much more aware of the requirement to transcribe the **entire** audio file, reducing instances of incomplete transcriptions.

## Testing
Users should test with audio files of varying lengths and verify that:
- First subtitle starts near 00:00:00,000
- Last subtitle timestamp approaches the actual audio duration
- No content is missing from the middle or end of the audio