### PR TITLE
feat: Add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,9 @@
 name: Test
 
-on: 
+on:
   push:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   test:
@@ -16,6 +16,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +31,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y ffmpeg
-  
+
       - name: Install the project
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Overview
Adds Python 3.14 to the GitHub Actions test workflow to ensure compatibility with the latest Python release.

## Changes
- Added Python 3.14 to the test matrix in `.github/workflows/test.yaml`
- Tests will now run against Python 3.10, 3.11, 3.12, 3.13, and 3.14

## Benefits
✅ Ensures forward compatibility with Python 3.14  
✅ Catches potential breaking changes early  
✅ Maintains backward compatibility with Python 3.10-3.13  
✅ Keeps the project up-to-date with the latest Python ecosystem  

## Testing
The CI will automatically run the full test suite against Python 3.14 when this PR is created.