### PR TITLE
feat: Add --model parameter to allow users to specify Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ sub-tools -i https://example.com/audio.mp3 --languages en es fr
 
 # Using local MP3 file
 sub-tools --tasks segment transcribe combine --audio-file audio.mp3 --languages en es fr
+
+# Specify a custom Gemini model (default: gemini-2.5-flash-lite)
+sub-tools -i https://example.com/video.mp4 --languages en --model gemini-2.5-flash-preview-04-17
 ```
 
 ### Build Docker

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -92,6 +92,13 @@ def build_parser() -> ArgumentParser:
         help="Gemini API Key. If not provided, the script tries to use the GEMINI_API_KEY environment variable.",
     )
 
+    parser.add_argument(
+        "--model",
+        "-m",
+        default="gemini-2.5-flash-lite",
+        help="Gemini model to use for transcription (default: %(default)s).",
+    )
+
     parser.add_argument("--debug", action="store_true", help="Enable debug mode.")
 
     parser.add_argument(

--- a/src/sub_tools/transcribe.py
+++ b/src/sub_tools/transcribe.py
@@ -14,7 +14,6 @@ from .system.language import get_language_name
 from .system.logger import write_log
 from .system.rate_limiter import RateLimiter
 
-model = "gemini-2.5-flash-lite"
 rate_limit = 10
 
 rate_limiter = RateLimiter(rate_limit=rate_limit, period=60)
@@ -53,6 +52,7 @@ async def _transcribe(parsed, config: Config) -> None:
                         offset,
                         language_code,
                         parsed.gemini_api_key,
+                        parsed.model,
                         parsed.retry,
                         parsed.debug,
                         parsed.overwrite,
@@ -75,6 +75,7 @@ async def _transcribe_item(
     offset: int,
     language_code: str,
     api_key: str,
+    model: str,
     retry: int,
     debug: bool,
     overwrite: bool,


### PR DESCRIPTION
## Summary

This PR adds support for users to specify custom Gemini models via the `--model` or `-m` CLI argument, addressing issue #49.

## Changes

### 1. Added `--model` CLI argument
- **File**: `src/sub_tools/arguments/parser.py`
- Added `--model` / `-m` argument with default value `gemini-2.5-flash-lite`
- Users can now specify any Gemini model available through the API

### 2. Removed hardcoded model
- **File**: `src/sub_tools/transcribe.py`
- Removed hardcoded `model = "gemini-2.5-flash-lite"` variable
- Added `model` parameter to `_transcribe_item()` function signature
- Threaded model parameter through the async transcription pipeline

### 3. Updated documentation
- **File**: `README.md`
- Added usage example showing how to specify custom models
- Documents the default model and shows the higher-quality model from the original issue

## Usage Examples

```bash
# Use default model (gemini-2.5-flash-lite)
sub-tools -i https://example.com/video.mp4 --languages en

# Use the higher-quality model mentioned in issue #49
sub-tools -i https://example.com/video.mp4 --languages en --model gemini-2.5-flash-preview-04-17

# Short form
sub-tools -i https://example.com/video.mp4 --languages en -m gemini-2.5-flash-preview-04-17
```

## Testing

- ✅ Code compiles without errors
- ✅ Backward compatible (default model unchanged)
- ✅ Model parameter correctly threaded through pipeline

## Related Issues

Resolves #49

## Breaking Changes

None. This change is fully backward compatible.