### PR TITLE
chore: Update rich to 14.2.0 and pytest-asyncio to 1.2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ dependencies = [
     "pycountry>=24.6.1",
     "pysrt>=1.1.2",
     "pytest>=9.0.1",
-    "pytest-asyncio>=0.23.5",
+    "pytest-asyncio>=1.2.0",
     "python-ffmpeg>=2.0.12",
-    "rich>=13.9.4",
+    "rich>=14.2.0",
     "whisperx>=3.1.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2967,16 +2967,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
 ]
 
 [[package]]
@@ -3500,9 +3499,9 @@ requires-dist = [
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pysrt", specifier = ">=1.1.2" },
     { name = "pytest", specifier = ">=9.0.1" },
-    { name = "pytest-asyncio", specifier = ">=0.23.5" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "python-ffmpeg", specifier = ">=2.0.12" },
-    { name = "rich", specifier = ">=13.9.4" },
+    { name = "rich", specifier = ">=14.2.0" },
     { name = "whisperx", specifier = ">=3.1.1" },
 ]
 


### PR DESCRIPTION
## Description
This PR updates two key dependencies to their latest stable versions:
- `rich` from 13.9.4 to >=14.2.0
- `pytest-asyncio` from 0.23.5 to >=1.2.0

## Changes
- Updated dependency versions in `pyproject.toml`
- Ran `uv sync` to update `uv.lock` with the new versions
- Verified all tests pass successfully

## Versions Installed
- rich: **14.2.0** (released October 9, 2025)
- pytest-asyncio: **1.3.0** (released November 10, 2025, latest stable version)

## Testing
✅ All async tests pass (`uv run pytest tests/test_rate_limiter.py`)
✅ All non-slow tests pass (`uv run pytest -m "not slow"`)
- 39 tests passed successfully
- No deprecation warnings observed
- Terminal output renders correctly with updated rich version

## Note on pytest-asyncio Version
The installed version is 1.3.0 (not 1.2.0 as mentioned in the issue). According to [PyPI](https://pypi.org/project/pytest-asyncio/), version 1.3.0 is the current stable release and is **not yanked**. It provides better support for pytest 9.x which this project uses.

Closes #58
Closes #60