### PR TITLE
feat: make Gemini 3.7 Flash primary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,10 @@ sub-tools is a Python toolkit for converting video/audio content into accurate, 
 ## Development Setup
 
 ```bash
-# Install uv package manager if not already installed
-# https://github.com/astral-sh/uv
-
 # Clone and setup
 git clone https://github.com/dohyeondk/sub-tools.git
 cd sub-tools
-uv sync
+./setup.sh  # installs uv and runs uv sync
 ```
 
 ## Common Commands
@@ -31,8 +28,8 @@ uv run sub-tools --tasks transcribe translate --audio-file audio.mp3 --languages
 # Only transcribe without translation
 uv run sub-tools --tasks transcribe --audio-file audio.mp3 --languages en
 
-# Specify custom model
-uv run sub-tools -i <url> --languages en --model gemini-3-pro-preview
+# Specify a custom Gemini model for proofreading/translation (default: gemini-3.7-flash)
+uv run sub-tools -i <url> --languages en --model gemini-3.6-flash
 ```
 
 ### Testing
@@ -69,18 +66,20 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 1. **video**: Downloads media from URL (HLS or direct) → `output/video.mp4`
 2. **audio**: Extracts audio track → `output/audio.mp3`
 3. **signature**: Generates Shazam signature for fingerprinting (macOS only)
-4. **transcribe**: Transcription using WhisperX (handles its own segmentation internally)
-5. **translate**: Proofreads and translates transcription using Gemini
+4. **transcribe**: Transcription using WhisperX only (handles its own segmentation internally)
+5. **translate**: Proofreads and translates the WhisperX transcript using the configured Gemini model
 
 ### Key Components
 
 **main.py**: Entry point that orchestrates the pipeline stages sequentially.
 
 **intelligence/whisperx.py**: Transcription using WhisperX
+- The only transcription backend in the pipeline; Gemini is never used to generate the initial transcript
 - High-quality speech recognition with word-level alignment
 - Uses config for all parameters (audio_file, source_language, model settings)
 
 **intelligence/gemini.py**: Proofreading and translation using Gemini
+- Uses the configured Gemini model; `--model` overrides it for proofreading/translation only
 - Proofread function: Fixes transcription errors using audio as reference
 - Translate function: Translates to multiple target languages
 - Uses config for all parameters (audio_file, languages, API key)
@@ -115,9 +114,9 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 
 **Config-Based Architecture**: All functions use the global config object instead of parameters. Functions like `download_from_url()`, `video_to_audio()`, `transcribe()`, `proofread()`, and `translate()` take no parameters and get values from `config`.
 
-**WhisperX Integration**: Uses WhisperX for state-of-the-art speech recognition with word-level timestamps. WhisperX handles audio segmentation internally using voice activity detection.
+**WhisperX Integration**: Uses WhisperX as the only transcription backend for state-of-the-art speech recognition with word-level timestamps. WhisperX handles audio segmentation internally using voice activity detection.
 
-**Gemini Integration**: Uses Gemini API with audio files as reference for both proofreading transcriptions and translating to target languages.
+**Gemini Integration**: Uses the configured Gemini model with audio files as reference for proofreading the WhisperX transcript and translating to target languages. Gemini does not replace WhisperX transcription.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A robust Python toolkit for converting video/audio content into accurate, multilingual subtitles using WhisperX for transcription and Google's Gemini API for proofreading and translation.
+A toolkit for multilingual subtitles: WhisperX transcribes, and Gemini proofreads and translates. Gemini 3.7 Flash is the primary model.
 
 ## ✨ Features
 
@@ -27,6 +27,14 @@ A robust Python toolkit for converting video/audio content into accurate, multil
 pip install sub-tools
 ```
 
+For a source checkout, run the setup script from a shell. It installs `uv` when it is
+missing, provisions a supported Python interpreter if needed, and syncs the project
+environment:
+
+```shell
+./setup.sh
+```
+
 ### Usage
 
 ```shell
@@ -47,8 +55,8 @@ sub-tools --tasks transcribe --audio-file audio.mp3 --languages en
 # Specify custom tasks (available: video, audio, signature, transcribe, translate)
 sub-tools -i https://example.com/video.mp4 --tasks video audio transcribe translate --languages en es
 
-# Specify a custom Gemini model (default: gemini-3-pro-preview)
-sub-tools -i https://example.com/video.mp4 --languages en --model gemini-2.5-pro
+# Specify a custom Gemini model for proofreading/translation
+sub-tools -i https://example.com/video.mp4 --languages en --model gemini-3.6-flash
 
 # Specify output directory (default: output)
 sub-tools -i https://example.com/video.mp4 --languages en --output my-subtitles
@@ -61,8 +69,8 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 1. **video**: Downloads media from URL (HLS or direct) → `video.mp4`
 2. **audio**: Extracts audio track → `audio.mp3`
 3. **signature**: Generates Shazam signature for fingerprinting (macOS only)
-4. **transcribe**: Transcription using WhisperX → `transcript.srt`
-5. **translate**: Proofreads and translates to target languages using Gemini → `{language}.srt`
+4. **transcribe**: Transcription using WhisperX only → `transcript.srt`
+5. **translate**: Proofreads and translates the WhisperX transcript using Gemini → `{language}.srt`
 
 By default, all tasks run. You can customize which tasks to run with `--tasks`.
 
@@ -70,6 +78,10 @@ By default, all tasks run. You can customize which tasks to run with `--tasks`.
 
 The evaluator is deliberately separate from model execution: it scores generated SRT
 files against a human reference so multiple runs can be compared on identical input.
+WhisperX is the only transcription engine in this project. Gemini models are evaluated
+as a post-processing step over the same WhisperX transcript, with timestamps preserved;
+the comparison therefore measures proofreading differences between Gemini models rather
+than comparing different transcription engines.
 The primary score is the published [SubER method](https://aclanthology.org/2022.iwslt-1.1/),
 implemented by the pinned [`subtitle-edit-rate==0.4.0`](https://pypi.org/project/subtitle-edit-rate/)
 package. SubER is reference-based and accounts for subtitle text, segmentation, and
@@ -108,8 +120,8 @@ models or pipeline stages:
 sub-tools-eval \
   --reference reference/en.srt \
   --hypothesis whisperx=output/transcript.srt \
-  --hypothesis gemini-3.7=output/gemini-3.7/en.srt \
-  --hypothesis gemini-3.6=output/gemini-3.6/en.srt \
+  --hypothesis gemini-3.7-flash=output/gemini-3.7-flash/en.srt \
+  --hypothesis gemini-3.6-flash=output/gemini-3.6-flash/en.srt \
   --output evals/transcription.json \
   --markdown evals/transcription.md
 ```
@@ -121,6 +133,10 @@ package.
 `sub-tools-eval` measures the text, segmentation, and timing quality of the assembled
 SRT output, while `sub-tools` remains responsible for producing the SRT. In particular,
 Gemini proofreading is evaluated with the timestamps WhisperX produced.
+
+To compare models, generate one WhisperX transcript and pass each Gemini output as a
+`--hypothesis`. The Markdown report shows one row per variant; lower error rates and
+higher BLEU/chrF indicate a closer match to the reference.
 
 ### Build Docker
 
@@ -136,13 +152,10 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for det
 ### Quick Development Setup
 
 ```shell
-# Install uv package manager
-# https://github.com/astral-sh/uv
-
 # Clone and setup
 git clone https://github.com/dohyeondk/sub-tools.git
 cd sub-tools
-uv sync
+./setup.sh  # installs uv and runs uv sync
 ```
 
 ## 🧪 Testing

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if ! command -v uv >/dev/null 2>&1 && ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to install uv. Install curl and run this script again." >&2
+    exit 1
+fi
+
+uv_command="$(command -v uv || true)"
+
+if [[ -z "$uv_command" ]]; then
+    echo "uv was not found; installing it with Astral's official installer..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    uv_candidates=()
+    if [[ -n "${UV_INSTALL_DIR:-}" ]]; then
+        uv_candidates+=("${UV_INSTALL_DIR}/uv")
+    fi
+    if [[ -n "${XDG_BIN_HOME:-}" ]]; then
+        uv_candidates+=("${XDG_BIN_HOME}/uv")
+    fi
+    uv_candidates+=("${HOME}/.local/bin/uv" "${HOME}/.cargo/bin/uv")
+
+    for candidate in "${uv_candidates[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            uv_command="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "$uv_command" ]]; then
+    echo "uv was installed, but its executable could not be located." >&2
+    echo "Add uv to PATH and run 'uv sync' manually." >&2
+    exit 1
+fi
+
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_directory"
+
+echo "Using $uv_command"
+"$uv_command" sync

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -108,7 +108,7 @@ def build_parser() -> ArgumentParser:
         "-m",
         dest="gemini_model",
         default=config.gemini_model,
-        help="Gemini model to use for transcription (default: %(default)s).",
+        help="Gemini model for proofreading and translation; transcription always uses WhisperX (default: %(default)s).",
     )
 
     parser.add_argument(

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -108,7 +108,7 @@ def build_parser() -> ArgumentParser:
         "-m",
         dest="gemini_model",
         default=config.gemini_model,
-        help="Gemini model for proofreading and translation; transcription always uses WhisperX (default: %(default)s).",
+        help="Gemini model to use (default: %(default)s).",
     )
 
     parser.add_argument(

--- a/src/sub_tools/config.py
+++ b/src/sub_tools/config.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field, fields
 from typing import Any
 
 
+DEFAULT_GEMINI_MODEL = "gemini-3.7-flash"
+
+
 @dataclass
 class Config:
     """
@@ -36,7 +39,7 @@ class Config:
 
     # Gemini
     gemini_api_key: str | None = None
-    gemini_model: str = "gemini-3-pro-preview"
+    gemini_model: str = DEFAULT_GEMINI_MODEL
 
     # WhisperX
     whisperx_model: str = "large-v2"  # WhisperX model to use

--- a/src/sub_tools/intelligence/gemini.py
+++ b/src/sub_tools/intelligence/gemini.py
@@ -23,7 +23,7 @@ def proofread() -> None:
 
 
 async def _proofread() -> None:
-    info("Proofreading using Gemini...")
+    info("Proofreading...")
 
     language_code = config.source_language
     language = get_language_name(language_code)
@@ -87,7 +87,7 @@ async def _translate() -> None:
     if not target_language_codes:
         return
 
-    info("Translating using Gemini...")
+    info("Translating...")
 
     tasks = []
 

--- a/src/sub_tools/intelligence/whisperx.py
+++ b/src/sub_tools/intelligence/whisperx.py
@@ -17,7 +17,7 @@ def transcribe() -> None:
     if should_skip(config.srt_file):
         return
 
-    info("Transcribing audio using WhisperX...")
+    info("Transcribing...")
 
     try:
         with _suppress_whisperx_output():
@@ -50,7 +50,7 @@ def transcribe() -> None:
             serialize_subtitles(result["segments"], config.srt_file)
 
     except Exception as e:
-        print(f"WhisperX transcription failed: {str(e)}")
+        print(f"Transcription failed: {str(e)}")
         raise
 
 


### PR DESCRIPTION
Updates the pipeline to use Gemini 3.7 Flash as the configured primary model while keeping WhisperX as the sole transcription backend.

Adds a portable uv setup script, updates model-comparison evaluation documentation, and simplifies CLI status/help output.

Validated with `uv run pytest tests/test_evaluation.py -q` and `bash -n setup.sh`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/298a3fff-3aa4-432c-bc99-0007d5175711)
