### PR TITLE
Add synchronized Gemini TTS dub task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A toolkit for multilingual subtitles. Gemini transcribes the audio and translate
 - 🧰 Automatic repair of malformed model output, with a retry when repair cannot save it
 - ✅ Strict validation that refuses to ship a broken subtitle file
 - 🌍 Multilingual translation that preserves the source timings
+- 🔊 Optional translated narration with Gemini TTS
 - 📥 Support for HLS streams, direct file URLs, and local files
 - 🎵 Audio fingerprinting using Shazam (macOS only)
 - 📊 Progress tracking with rich terminal output
@@ -53,7 +54,10 @@ sub-tools --tasks transcribe translate --audio-file audio.mp3 --languages en es 
 # Only transcribe without translation
 sub-tools --tasks transcribe --audio-file audio.mp3 --languages en
 
-# Specify custom tasks (available: video, audio, signature, transcribe, translate)
+# Generate simple translated narration from existing translated SRT files
+sub-tools --tasks dub --languages en es fr
+
+# Specify custom tasks (available: video, audio, signature, transcribe, translate, dub)
 sub-tools -i https://example.com/video.mp4 --tasks video audio transcribe translate --languages en es
 
 # Specify a custom Gemini model for transcription and translation
@@ -72,8 +76,16 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 3. **signature**: Generates Shazam signature for fingerprinting (macOS only)
 4. **transcribe**: Gemini turns the audio into subtitles → `{source-language}.srt`
 5. **translate**: Gemini translates those subtitles into each target language → `{language}.srt`
+6. **dub**: Gemini TTS reads each translated subtitle file → `{language}.wav`
 
-By default, all tasks run. You can customize which tasks to run with `--tasks`.
+The `dub` task is opt-in; the existing five tasks continue to run by
+default. It uses `gemini-3.1-flash-tts-preview` and the `Sadaltager` voice unless you pass
+`--tts-model` or `--tts-voice`.
+
+Gemini 3.7 Flash supports audio input but not audio output, so `dub` sends the
+translated SRT text to the dedicated TTS model. It fits gap-aware audio chunks to
+the subtitle timeline and writes a WAV matching the original duration. This does
+not preserve or mix the original speakers, music, or audience reactions.
 
 ## 📏 Transcription evaluation
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 6. **dub**: Gemini TTS reads each translated subtitle file → `{language}.wav`
 
 The `dub` task is opt-in; the existing five tasks continue to run by
-default. It uses `gemini-3.1-flash-tts-preview` and the `Sadaltager` voice unless you pass
+default. It uses `gemini-2.5-flash-preview-tts` and the `Sadaltager` voice unless you pass
 `--tts-model` or `--tts-voice`.
 
 Gemini 3.7 Flash supports audio input but not audio output, so `dub` sends the

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -106,6 +106,34 @@ def build_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--tts-model",
+        dest="gemini_tts_model",
+        default=config.gemini_tts_model,
+        help="Gemini TTS model for the dub task (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--tts-voice",
+        dest="gemini_tts_voice",
+        default=config.gemini_tts_voice,
+        help="Gemini prebuilt voice for the dub task (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--dub-chunk-duration",
+        type=float,
+        default=config.dub_chunk_duration,
+        help="Maximum seconds per synchronized dub request (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--dub-gap-threshold",
+        type=float,
+        default=config.dub_gap_threshold,
+        help="Seconds of subtitle silence preserved between dub chunks (default: %(default)s).",
+    )
+
+    parser.add_argument(
         "--debug",
         action="store_true",
         default=config.debug,

--- a/src/sub_tools/config.py
+++ b/src/sub_tools/config.py
@@ -7,7 +7,7 @@ from typing import Any
 
 
 DEFAULT_GEMINI_MODEL = "gemini-3.7-flash"
-DEFAULT_GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview"
+DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 
 
 @dataclass

--- a/src/sub_tools/config.py
+++ b/src/sub_tools/config.py
@@ -7,6 +7,7 @@ from typing import Any
 
 
 DEFAULT_GEMINI_MODEL = "gemini-3.7-flash"
+DEFAULT_GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview"
 
 
 @dataclass
@@ -39,6 +40,12 @@ class Config:
     # Gemini
     gemini_api_key: str | None = None
     gemini_model: str = DEFAULT_GEMINI_MODEL
+    gemini_tts_model: str = DEFAULT_GEMINI_TTS_MODEL
+    gemini_tts_voice: str = "Sadaltager"
+
+    # Dub synchronization
+    dub_chunk_duration: float = 60.0
+    dub_gap_threshold: float = 2.0
 
     # Validation
     max_valid_duration: int = (

--- a/src/sub_tools/intelligence/gemini.py
+++ b/src/sub_tools/intelligence/gemini.py
@@ -252,7 +252,8 @@ async def _generate_dub_language(
         info(f"{language_code}.wav: generating chunk {index}/{len(groups)}")
         audio, mime_type = await _call_tts_api(prompt)
         pcm, sample_rate = _pcm_audio(audio, mime_type)
-        start, end = group[0].start, min(group[-1].end, duration)
+        start = group[0].start
+        end = min(max(cue.end for cue in group), duration)
         if start >= end:
             continue
         segments.append((start, end, _fit_pcm_duration(pcm, sample_rate, end - start)))
@@ -268,20 +269,32 @@ def _dub_groups(cues: list[Cue]) -> list[list[Cue]]:
     if config.dub_gap_threshold < 0:
         raise ValueError("Dub gap threshold cannot be negative")
 
-    groups = []
-    current = []
+    groups: list[list[Cue]] = []
+    current: list[Cue] = []
     for cue in cues:
-        starts_after_gap = (
-            current and cue.start - current[-1].end >= config.dub_gap_threshold
-        )
-        exceeds_window = (
-            current
-            and cue.end - current[0].start > config.dub_chunk_duration
-            and cue.start >= current[-1].end
-        )
-        if starts_after_gap or exceeds_window:
-            groups.append(current)
-            current = []
+        if cue.end - cue.start > config.dub_chunk_duration:
+            raise ValueError(
+                f"Subtitle #{cue.index} spans {cue.end - cue.start:.1f}s, exceeding the "
+                f"{config.dub_chunk_duration:.1f}s dub chunk duration"
+            )
+
+        if current:
+            current_end = max(item.end for item in current)
+            starts_after_gap = (
+                cue.start - current_end >= config.dub_gap_threshold
+            )
+            exceeds_window = (
+                max(current_end, cue.end) - current[0].start
+                > config.dub_chunk_duration
+            )
+            if exceeds_window and cue.start < current_end:
+                raise ValueError(
+                    "Overlapping subtitle cues exceed the configured dub chunk "
+                    "duration; increase --dub-chunk-duration or fix the subtitle timings"
+                )
+            if starts_after_gap or exceeds_window:
+                groups.append(current)
+                current = []
         current.append(cue)
     if current:
         groups.append(current)

--- a/src/sub_tools/intelligence/gemini.py
+++ b/src/sub_tools/intelligence/gemini.py
@@ -1,4 +1,10 @@
 import asyncio
+import io
+import os
+import re
+import subprocess
+import tempfile
+import wave
 from typing import Callable, Optional
 
 from google import genai
@@ -13,7 +19,16 @@ from sub_tools.system.language import get_language_name
 from ..config import config
 from ..media.converter import audio_duration
 from ..subtitles.repair import repair_subtitles
-from ..subtitles.validator import SubtitleValidationError, find_problems
+from ..subtitles.validator import (
+    Cue,
+    SubtitleValidationError,
+    find_problems,
+    parse_strict,
+)
+
+PCM_SAMPLE_RATE = 24_000
+PCM_SAMPLE_WIDTH = 2
+PCM_CHANNELS = 1
 
 
 def transcribe() -> None:
@@ -156,6 +171,302 @@ async def _translate_language(
         reference=srt_content,
     )
     completion()
+
+
+def dub() -> None:
+    """
+    Generate a simple spoken rendition of each translated subtitle file.
+
+    Gemini 3.7 cannot return audio, and Gemini TTS models cannot accept the
+    original audio. This task therefore sends the translated text alone to the
+    separately configured TTS model. The result is coarse timeline-aligned
+    narration, not a cue-timed dub.
+    """
+    asyncio.run(_dub())
+
+
+async def _dub() -> None:
+    target_language_codes = [
+        language
+        for language in config.languages
+        if language != config.source_language and not should_skip(f"{language}.wav")
+    ]
+
+    if not target_language_codes:
+        return
+
+    info("Generating translated audio...")
+
+    with Progress() as progress:
+        progress_task = progress.add_task(
+            "Translated audio", total=len(target_language_codes)
+        )
+        tasks = [
+            asyncio.create_task(
+                _generate_dub_language(
+                    language_code,
+                    completion=lambda: progress.update(progress_task, advance=1),
+                )
+            )
+            for language_code in target_language_codes
+        ]
+        await asyncio.gather(*tasks)
+
+
+async def _generate_dub_language(
+    language_code: str,
+    completion: Callable[[], None],
+) -> None:
+    subtitle_file = f"{language_code}.srt"
+    with open(subtitle_file, "r", encoding="utf-8") as f:
+        srt_content = f.read()
+
+    duration = audio_duration(config.audio_file)
+    if duration is None:
+        raise RuntimeError(
+            "Cannot synchronize translated audio without the original audio duration"
+        )
+
+    cues, errors = parse_strict(srt_content)
+    if errors:
+        details = "; ".join(errors)
+        raise SubtitleValidationError(
+            f"Cannot generate translated audio from {subtitle_file}: {details}"
+        )
+    validation_errors, _ = find_problems(srt_content, duration=duration)
+    if validation_errors:
+        details = "; ".join(validation_errors)
+        raise SubtitleValidationError(
+            f"Cannot synchronize translated audio from {subtitle_file}: {details}"
+        )
+    language = get_language_name(language_code)
+    groups = _dub_groups(cues)
+    segments: list[tuple[float, float, bytes]] = []
+    for index, group in enumerate(groups, start=1):
+        speech_text = "\n".join(cue.text.replace("\n", " ") for cue in group)
+        prompt = (
+            f"Synthesize speech in {language}. Read the actual transcript naturally "
+            "and exactly. Do not add, remove, or translate any words.\n\n"
+            f"ACTUAL TRANSCRIPT:\n{speech_text}"
+        )
+        info(f"{language_code}.wav: generating chunk {index}/{len(groups)}")
+        audio, mime_type = await _call_tts_api(prompt)
+        pcm, sample_rate = _pcm_audio(audio, mime_type)
+        start, end = group[0].start, min(group[-1].end, duration)
+        if start >= end:
+            continue
+        segments.append((start, end, _fit_pcm_duration(pcm, sample_rate, end - start)))
+
+    _write_synced_audio(f"{language_code}.wav", segments, duration)
+    completion()
+
+
+def _dub_groups(cues: list[Cue]) -> list[list[Cue]]:
+    """Group nearby cues into bounded TTS requests while preserving long gaps."""
+    if config.dub_chunk_duration <= 0:
+        raise ValueError("Dub chunk duration must be greater than zero")
+    if config.dub_gap_threshold < 0:
+        raise ValueError("Dub gap threshold cannot be negative")
+
+    groups = []
+    current = []
+    for cue in cues:
+        starts_after_gap = (
+            current and cue.start - current[-1].end >= config.dub_gap_threshold
+        )
+        exceeds_window = (
+            current
+            and cue.end - current[0].start > config.dub_chunk_duration
+            and cue.start >= current[-1].end
+        )
+        if starts_after_gap or exceeds_window:
+            groups.append(current)
+            current = []
+        current.append(cue)
+    if current:
+        groups.append(current)
+    return groups
+
+
+async def _call_tts_api(text: str) -> tuple[bytes, str]:
+    """Ask the configured Gemini TTS model for one audio response."""
+    client = genai.Client(api_key=config.gemini_api_key)
+    attempts = max(1, config.retry)
+
+    for attempt in range(attempts):
+        try:
+            response = await client.aio.models.generate_content(
+                model=config.gemini_tts_model,
+                contents=text,
+                config=types.GenerateContentConfig(
+                    response_modalities=["AUDIO"],
+                    speech_config=types.SpeechConfig(
+                        voice_config=types.VoiceConfig(
+                            prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                                voice_name=config.gemini_tts_voice
+                            )
+                        )
+                    ),
+                ),
+            )
+            return _audio_response(response)
+        except (
+            google_exceptions.InternalServerError,
+            google_exceptions.ResourceExhausted,
+            google_exceptions.ServiceUnavailable,
+        ):
+            if attempt < attempts - 1:
+                await asyncio.sleep(_backoff(attempt))
+                continue
+            raise
+        except Exception as e:
+            message = str(e)
+            transient = any(status in message for status in ("429", "500", "503"))
+            if transient and attempt < attempts - 1:
+                await asyncio.sleep(_backoff(attempt))
+                continue
+            raise
+
+    raise RuntimeError("Gemini TTS did not return a response")
+
+
+def _audio_response(response: types.GenerateContentResponse) -> tuple[bytes, str]:
+    """Extract audio bytes and their MIME type from a GenerateContent response."""
+    candidates = response.candidates or []
+    if not candidates or not candidates[0].content:
+        raise RuntimeError("Gemini TTS response contained no audio")
+
+    parts = candidates[0].content.parts or []
+    blobs = [
+        part.inline_data for part in parts if part.inline_data and part.inline_data.data
+    ]
+    if not blobs:
+        raise RuntimeError("Gemini TTS response contained no audio")
+
+    mime_types = {blob.mime_type for blob in blobs if blob.mime_type}
+    if len(mime_types) > 1:
+        raise RuntimeError("Gemini TTS response contained incompatible audio formats")
+    return b"".join(blob.data for blob in blobs), next(
+        iter(mime_types), "audio/L16;rate=24000"
+    )
+
+
+def _pcm_audio(audio: bytes, mime_type: str) -> tuple[bytes, int]:
+    """Return mono 16-bit PCM data and its sample rate."""
+    normalized_mime_type = mime_type.lower()
+    if normalized_mime_type.startswith(("audio/wav", "audio/x-wav")):
+        with wave.open(io.BytesIO(audio), "rb") as wav_file:
+            if wav_file.getnchannels() != PCM_CHANNELS:
+                raise RuntimeError("Gemini TTS returned non-mono WAV audio")
+            if wav_file.getsampwidth() != PCM_SAMPLE_WIDTH:
+                raise RuntimeError("Gemini TTS returned non-16-bit WAV audio")
+            return wav_file.readframes(wav_file.getnframes()), wav_file.getframerate()
+
+    if not normalized_mime_type.startswith(("audio/l16", "audio/pcm")):
+        raise RuntimeError(f"Gemini TTS returned unsupported audio format: {mime_type}")
+    rate_match = re.search(r"(?:^|;)\s*rate=(\d+)", normalized_mime_type)
+    return audio, int(rate_match.group(1)) if rate_match else PCM_SAMPLE_RATE
+
+
+def _atempo_filter(speed: float) -> str:
+    """Build a portable FFmpeg atempo chain for the requested speed."""
+    factors = []
+    while speed < 0.5:
+        factors.append(0.5)
+        speed /= 0.5
+    while speed > 2.0:
+        factors.append(2.0)
+        speed /= 2.0
+    factors.append(speed)
+    return ",".join(f"atempo={factor:.8f}" for factor in factors)
+
+
+def _fit_pcm_duration(pcm: bytes, sample_rate: int, target_duration: float) -> bytes:
+    """Time-stretch PCM to a subtitle window without changing pitch."""
+    if not pcm or target_duration <= 0:
+        raise RuntimeError("Cannot synchronize empty or zero-length dub audio")
+    source_duration = len(pcm) / (sample_rate * PCM_SAMPLE_WIDTH * PCM_CHANNELS)
+    speed = source_duration / target_duration
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "s16le",
+        "-ar",
+        str(sample_rate),
+        "-ac",
+        str(PCM_CHANNELS),
+        "-i",
+        "pipe:0",
+        "-filter:a",
+        _atempo_filter(speed),
+        "-ar",
+        str(PCM_SAMPLE_RATE),
+        "-ac",
+        str(PCM_CHANNELS),
+        "-f",
+        "s16le",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(cmd, input=pcm, check=True, capture_output=True)
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "FFmpeg is required to synchronize translated audio"
+        ) from error
+    except subprocess.CalledProcessError as error:
+        details = error.stderr.decode(errors="replace").strip()
+        raise RuntimeError(
+            f"Failed to synchronize translated audio: {details}"
+        ) from error
+
+    if not result.stdout:
+        raise RuntimeError("FFmpeg returned no synchronized audio")
+    target_bytes = round(target_duration * PCM_SAMPLE_RATE) * PCM_SAMPLE_WIDTH
+    return result.stdout[:target_bytes].ljust(target_bytes, b"\0")
+
+
+def _write_synced_audio(
+    output_file: str,
+    segments: list[tuple[float, float, bytes]],
+    duration: float,
+) -> None:
+    """Write fitted speech at its timeline positions as an atomic WAV output."""
+    directory = os.path.dirname(os.path.abspath(output_file))
+    wav_temporary = tempfile.NamedTemporaryFile(
+        prefix=".dub-", suffix=".wav", dir=directory, delete=False
+    )
+    wav_temporary.close()
+    try:
+        with wave.open(wav_temporary.name, "wb") as wav_file:
+            wav_file.setnchannels(PCM_CHANNELS)
+            wav_file.setsampwidth(PCM_SAMPLE_WIDTH)
+            wav_file.setframerate(PCM_SAMPLE_RATE)
+            position = 0
+            for start, end, pcm in segments:
+                start_frame = round(start * PCM_SAMPLE_RATE)
+                end_frame = round(end * PCM_SAMPLE_RATE)
+                if start_frame < position:
+                    raise RuntimeError("Translated subtitle windows overlap")
+                wav_file.writeframes(
+                    b"\0" * ((start_frame - position) * PCM_SAMPLE_WIDTH)
+                )
+                target_bytes = (end_frame - start_frame) * PCM_SAMPLE_WIDTH
+                wav_file.writeframes(pcm[:target_bytes].ljust(target_bytes, b"\0"))
+                position = end_frame
+
+            final_frame = round(duration * PCM_SAMPLE_RATE)
+            if position > final_frame:
+                raise RuntimeError(
+                    "Translated audio extends beyond the source duration"
+                )
+            wav_file.writeframes(b"\0" * ((final_frame - position) * PCM_SAMPLE_WIDTH))
+        os.replace(wav_temporary.name, output_file)
+    finally:
+        if os.path.exists(wav_temporary.name):
+            os.unlink(wav_temporary.name)
 
 
 async def _generate_subtitles(

--- a/src/sub_tools/main.py
+++ b/src/sub_tools/main.py
@@ -1,4 +1,4 @@
-from sub_tools.intelligence.gemini import transcribe, translate
+from sub_tools.intelligence.gemini import dub, transcribe, translate
 
 from .arguments.parser import build_parser, parse_args
 from .config import config
@@ -50,6 +50,15 @@ def main():
 
             header(f"{step}. Translate")
             translate()
+            step += 1
+
+        if "dub" in config.tasks:
+            if not (config.gemini_api_key and config.gemini_api_key.strip()):
+                parsed.func()
+                raise Exception("No Gemini API Key provided")
+
+            header(f"{step}. Dub")
+            dub()
             step += 1
 
     except Exception as e:

--- a/src/sub_tools/media/converter.py
+++ b/src/sub_tools/media/converter.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 from sub_tools.system.file import should_skip
@@ -75,8 +76,26 @@ def audio_duration(path: str) -> float | None:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
         return float(result.stdout.strip())
     except (subprocess.SubprocessError, FileNotFoundError, ValueError):
-        warning("Could not measure audio duration; skipping coverage checks.")
-        return None
+        pass
+
+    # ffprobe is normally installed with ffmpeg, but some distributions package
+    # only the latter. Its input summary still contains the exact media duration.
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-i", path],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        match = re.search(r"Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)", result.stderr)
+        if match:
+            hours, minutes, seconds = match.groups()
+            return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    warning("Could not measure audio duration; skipping coverage checks.")
+    return None
 
 
 def media_to_signature() -> None:

--- a/tests/test_dub.py
+++ b/tests/test_dub.py
@@ -1,0 +1,227 @@
+import asyncio
+import importlib
+import sys
+import wave
+from copy import deepcopy
+from dataclasses import fields
+from types import SimpleNamespace
+
+import pytest
+
+from sub_tools.config import Config, config
+from sub_tools.intelligence import gemini
+from sub_tools.media import converter
+from sub_tools.subtitles.validator import Cue
+
+VALID_SPANISH_SRT = """1
+00:00:00,000 --> 00:00:01,000
+Hola mundo.
+
+2
+00:00:01,000 --> 00:00:02,000
+¿Cómo estás?
+"""
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    original = {
+        field.name: deepcopy(getattr(config, field.name)) for field in fields(Config)
+    }
+    yield
+    for name, value in original.items():
+        setattr(config, name, value)
+
+
+def test_tts_request_uses_audio_modality_and_configured_voice(monkeypatch):
+    pcm = b"\x01\x00\x02\x00"
+    captured = {}
+    response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[
+                        SimpleNamespace(
+                            inline_data=SimpleNamespace(
+                                data=pcm,
+                                mime_type="audio/L16;codec=pcm;rate=24000",
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    )
+
+    class Models:
+        async def generate_content(self, **kwargs):
+            captured.update(kwargs)
+            return response
+
+    client = SimpleNamespace(aio=SimpleNamespace(models=Models()))
+    monkeypatch.setattr(gemini.genai, "Client", lambda api_key: client)
+    config.gemini_api_key = "test-key"
+    config.gemini_tts_model = "gemini-3.1-flash-tts-preview"
+    config.gemini_tts_voice = "Puck"
+
+    audio, mime_type = asyncio.run(gemini._call_tts_api("Hola mundo."))
+
+    assert audio == pcm
+    assert mime_type == "audio/L16;codec=pcm;rate=24000"
+    assert captured["model"] == "gemini-3.1-flash-tts-preview"
+    assert captured["contents"] == "Hola mundo."
+    assert captured["config"].response_modalities == ["AUDIO"]
+    voice = captured["config"].speech_config.voice_config.prebuilt_voice_config
+    assert voice.voice_name == "Puck"
+
+
+def test_generates_wav_from_translated_subtitle_text(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "es.srt").write_text(VALID_SPANISH_SRT, encoding="utf-8")
+    captured = {}
+
+    async def fake_call_tts_api(text):
+        captured["text"] = text
+        return b"\x01\x00\x02\x00", "audio/L16;codec=pcm;rate=16000"
+
+    monkeypatch.setattr(gemini, "_call_tts_api", fake_call_tts_api)
+    monkeypatch.setattr(gemini, "audio_duration", lambda path: 1.5)
+    monkeypatch.setattr(
+        gemini,
+        "_fit_pcm_duration",
+        lambda pcm, sample_rate, duration: (
+            b"\x01\x00" * round(duration * gemini.PCM_SAMPLE_RATE)
+        ),
+    )
+    config.audio_file = "audio.mp3"
+
+    asyncio.run(gemini._generate_dub_language("es", lambda: None))
+
+    assert "Hola mundo." in captured["text"]
+    assert "¿Cómo estás?" in captured["text"]
+    assert "00:00:00,000" not in captured["text"]
+    with wave.open(str(tmp_path / "es.wav"), "rb") as wav_file:
+        assert wav_file.getframerate() == 24000
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.readframes(2) == b"\x01\x00\x01\x00"
+        assert wav_file.getnframes() == 36000
+
+
+def test_dub_groups_preserve_long_gaps_and_limit_drift():
+    config.dub_chunk_duration = 60
+    config.dub_gap_threshold = 2
+    cues = [
+        Cue(index=1, start=0, end=10, text="one"),
+        Cue(index=2, start=10, end=20, text="two"),
+        Cue(index=3, start=23, end=30, text="three"),
+        Cue(index=4, start=31, end=95, text="four"),
+    ]
+
+    groups = gemini._dub_groups(cues)
+
+    assert [[cue.index for cue in group] for group in groups] == [
+        [1, 2],
+        [3],
+        [4],
+    ]
+
+
+def test_audio_duration_falls_back_to_ffmpeg(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "ffprobe":
+            raise FileNotFoundError
+        return SimpleNamespace(stderr="Duration: 00:33:47.62, start: 0.011")
+
+    monkeypatch.setattr(converter.subprocess, "run", fake_run)
+
+    assert converter.audio_duration("audio.mp3") == pytest.approx(2027.62)
+
+
+def test_audio_response_must_contain_audio():
+    response = SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]))]
+    )
+
+    with pytest.raises(RuntimeError, match="contained no audio"):
+        gemini._audio_response(response)
+
+
+def test_tts_retries_transient_internal_server_errors(monkeypatch):
+    calls = 0
+    response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[
+                        SimpleNamespace(
+                            inline_data=SimpleNamespace(
+                                data=b"\x01\x00",
+                                mime_type="audio/L16;rate=24000",
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+    )
+
+    class Models:
+        async def generate_content(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise gemini.google_exceptions.InternalServerError("temporary")
+            return response
+
+    async def no_sleep(delay):
+        return None
+
+    client = SimpleNamespace(aio=SimpleNamespace(models=Models()))
+    monkeypatch.setattr(gemini.genai, "Client", lambda api_key: client)
+    monkeypatch.setattr(gemini.asyncio, "sleep", no_sleep)
+    config.retry = 2
+
+    audio, _ = asyncio.run(gemini._call_tts_api("Hola mundo."))
+
+    assert audio == b"\x01\x00"
+    assert calls == 2
+
+
+def test_main_wires_dub_task(monkeypatch, tmp_path):
+    main_module = importlib.import_module("sub_tools.main")
+    calls = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "sub-tools",
+            "--tasks",
+            "dub",
+            "--gemini-api-key",
+            "test-key",
+            "--output",
+            str(tmp_path),
+            "--dub-chunk-duration",
+            "30",
+            "--dub-gap-threshold",
+            "1.5",
+        ],
+    )
+    monkeypatch.setattr(main_module, "ensure_output_directory", lambda path: None)
+    monkeypatch.setattr(main_module, "header", lambda title: None)
+    monkeypatch.setattr(
+        main_module,
+        "dub",
+        lambda: calls.append(
+            ("dub", config.dub_chunk_duration, config.dub_gap_threshold)
+        ),
+    )
+
+    main_module.main()
+
+    assert calls == [("dub", 30, 1.5)]
+
+
+def test_dub_remains_opt_in():
+    assert "dub" not in Config().tasks

--- a/tests/test_dub.py
+++ b/tests/test_dub.py
@@ -224,4 +224,7 @@ def test_main_wires_dub_task(monkeypatch, tmp_path):
 
 
 def test_dub_remains_opt_in():
-    assert "dub" not in Config().tasks
+    defaults = Config()
+
+    assert "dub" not in defaults.tasks
+    assert defaults.gemini_tts_model == "gemini-2.5-flash-preview-tts"

--- a/tests/test_dub.py
+++ b/tests/test_dub.py
@@ -108,6 +108,32 @@ def test_generates_wav_from_translated_subtitle_text(tmp_path, monkeypatch):
         assert wav_file.getnframes() == 36000
 
 
+def test_dub_window_uses_latest_end_for_overlapping_cues(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "es.srt").write_text(
+        "1\n00:00:00,000 --> 00:00:10,000\nPrimero.\n\n"
+        "2\n00:00:02,000 --> 00:00:03,000\nSegundo.\n",
+        encoding="utf-8",
+    )
+    fitted_durations = []
+
+    async def fake_call_tts_api(text):
+        return b"\x01\x00", "audio/L16;rate=24000"
+
+    def fake_fit_pcm_duration(pcm, sample_rate, duration):
+        fitted_durations.append(duration)
+        return b"\x01\x00" * round(duration * gemini.PCM_SAMPLE_RATE)
+
+    monkeypatch.setattr(gemini, "_call_tts_api", fake_call_tts_api)
+    monkeypatch.setattr(gemini, "audio_duration", lambda path: 10.0)
+    monkeypatch.setattr(gemini, "_fit_pcm_duration", fake_fit_pcm_duration)
+    config.audio_file = "audio.mp3"
+
+    asyncio.run(gemini._generate_dub_language("es", lambda: None))
+
+    assert fitted_durations == [10.0]
+
+
 def test_dub_groups_preserve_long_gaps_and_limit_drift():
     config.dub_chunk_duration = 60
     config.dub_gap_threshold = 2
@@ -115,7 +141,7 @@ def test_dub_groups_preserve_long_gaps_and_limit_drift():
         Cue(index=1, start=0, end=10, text="one"),
         Cue(index=2, start=10, end=20, text="two"),
         Cue(index=3, start=23, end=30, text="three"),
-        Cue(index=4, start=31, end=95, text="four"),
+        Cue(index=4, start=31, end=90, text="four"),
     ]
 
     groups = gemini._dub_groups(cues)
@@ -125,6 +151,24 @@ def test_dub_groups_preserve_long_gaps_and_limit_drift():
         [3],
         [4],
     ]
+
+
+def test_dub_groups_reject_oversized_cues():
+    config.dub_chunk_duration = 10
+
+    with pytest.raises(ValueError, match="Subtitle #1 spans 11.0s"):
+        gemini._dub_groups([Cue(index=1, start=0, end=11, text="too long")])
+
+
+def test_dub_groups_reject_overlapping_window_overflow():
+    config.dub_chunk_duration = 10
+    cues = [
+        Cue(index=1, start=0, end=8, text="one"),
+        Cue(index=2, start=7, end=15, text="two"),
+    ]
+
+    with pytest.raises(ValueError, match="Overlapping subtitle cues"):
+        gemini._dub_groups(cues)
 
 
 def test_audio_duration_falls_back_to_ffmpeg(monkeypatch):


### PR DESCRIPTION
## Summary

- Add an opt-in `dub` pipeline task that synthesizes translated SRT text with a dedicated Gemini TTS model and writes timeline-aligned WAV output.
- Validate subtitles, preserve long gaps, fit coarse chunks to subtitle windows, and atomically match the original audio duration.
- Add TTS and synchronization CLI/config options, an FFmpeg duration fallback, focused mocks/tests, and concise README usage and API-limit documentation.

## Testing

`PATH="$PWD/.context/test-bin:$PATH" uv run pytest -q -m "not slow"` — 53 passed, 1 deselected.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/562944bb-7317-4b2b-bc16-4742de58e515)
