### PR TITLE
Increase default Gemini dub chunk duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ default. It uses `gemini-2.5-flash-preview-tts` and the `Sadaltager` voice unles
 `--tts-model` or `--tts-voice`.
 
 Gemini 3.7 Flash supports audio input but not audio output, so `dub` sends the
-translated SRT text to the dedicated TTS model. It fits gap-aware audio chunks to
-the subtitle timeline and writes a WAV matching the original duration. This does
-not preserve or mix the original speakers, music, or audience reactions.
+translated SRT text to the dedicated TTS model. It fits gap-aware audio chunks
+(up to 300 seconds by default) to the subtitle timeline and writes a WAV matching
+the original duration. This does not preserve or mix the original speakers, music,
+or audience reactions.
 
 ## 📏 Transcription evaluation
 

--- a/src/sub_tools/config.py
+++ b/src/sub_tools/config.py
@@ -44,7 +44,7 @@ class Config:
     gemini_tts_voice: str = "Sadaltager"
 
     # Dub synchronization
-    dub_chunk_duration: float = 60.0
+    dub_chunk_duration: float = 300.0
     dub_gap_threshold: float = 2.0
 
     # Validation

--- a/tests/test_dub.py
+++ b/tests/test_dub.py
@@ -272,3 +272,4 @@ def test_dub_remains_opt_in():
 
     assert "dub" not in defaults.tasks
     assert defaults.gemini_tts_model == "gemini-2.5-flash-preview-tts"
+    assert defaults.dub_chunk_duration == 300.0


### PR DESCRIPTION
Increase the default synchronized Gemini TTS dub chunk duration from 60 seconds to 300 seconds to reduce request volume while preserving timeline fitting. Document the new default and add coverage for the configuration value. Tests: ============================= test session starts ==============================
platform linux -- Python 3.13.15, pytest-9.0.1, pluggy-1.5.0
rootdir: /home/vercel-sandbox/sub-tools
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 11 items

tests/test_dub.py ...........                                            [100%]

============================== 11 passed in 1.11s ============================== (11 passed); the broader suite has four pre-existing environment failures because ffmpeg is unavailable.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/354a7a4e-a9a7-4ea3-9b2e-87064a76610b)
