### PR TITLE
feat: add multi-provider and OpenRouter audio support

### DIFF
--- a/.github/workflows/publish-ci-images.yml
+++ b/.github/workflows/publish-ci-images.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      # One-time bootstrap for the existing PR; remove after the first image
+      # set has been published to GHCR.
+      - dk/harare-v1
     paths:
       - Dockerfile.ci
       - .github/workflows/publish-ci-images.yml

--- a/.github/workflows/publish-ci-images.yml
+++ b/.github/workflows/publish-ci-images.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-      # One-time bootstrap for the existing PR; remove after the first image
-      # set has been published to GHCR.
-      - dk/harare-v1
     paths:
       - Dockerfile.ci
       - .github/workflows/publish-ci-images.yml

--- a/.github/workflows/publish-ci-images.yml
+++ b/.github/workflows/publish-ci-images.yml
@@ -1,0 +1,66 @@
+name: Publish CI images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile.ci
+      - .github/workflows/publish-ci-images.yml
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-ci-images
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}-ci
+
+jobs:
+  publish:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push CI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ci
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:python${{ matrix.python-version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=ci-python-${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=ci-python-${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,10 +5,24 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     name: Test with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/${{ github.repository }}-ci:python${{ matrix.python-version }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         python-version:
@@ -20,19 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "0.5.14"
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup FFmpeg
-        run: |
-          sudo apt update
-          sudo apt install -y ffmpeg
-
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --frozen --all-extras --dev
 
       - name: Run tests
         run: uv run pytest -m "not slow"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to agents when working with code in this repository.
 
 ## Project Overview
 
-sub-tools is a Python toolkit for converting video/audio content into accurate, multilingual subtitles using Google's Gemini API (default) or OpenAI models for transcription and translation, plus text-to-speech dubbing of the results. Model output is repaired and strictly validated before it is accepted. The tool supports HLS streams, direct file URLs, and local files.
+sub-tools is a Python toolkit for converting video/audio content into accurate, multilingual subtitles using Google Gemini (default), Anthropic, OpenAI, or OpenRouter models for transcription and translation, plus text-to-speech dubbing of the results. Model output is repaired and strictly validated before it is accepted. The tool supports HLS streams, direct file URLs, and local files.
 
 ## Development Setup
 
@@ -31,8 +31,13 @@ uv run sub-tools --tasks transcribe --audio-file audio.mp3 --languages en
 # Specify a custom Gemini model for transcription and translation (default: gemini-3.7-flash)
 uv run sub-tools -i <url> --languages en --model gemini-3.6-flash
 
-# Use an OpenAI model instead; provider is inferred from the model name (needs OPENAI_API_KEY)
-uv run sub-tools -i <url> --languages en --model gpt-5.6-luna
+# Use an OpenAI model explicitly (needs OPENAI_API_KEY)
+uv run sub-tools -i <url> --languages en --provider openai --model gpt-5.6-luna
+
+# Use an arbitrary OpenRouter model and audio model (needs OPENROUTER_API_KEY)
+uv run sub-tools --tasks transcribe translate --audio-file audio.mp3 --languages en \
+  --provider openrouter --model anthropic/claude-sonnet-4 \
+  --audio-model google/gemini-2.5-flash
 
 # Dub: speak the generated subtitles into a timing-aligned {language}.mp3
 uv run sub-tools --tasks transcribe translate dub --audio-file audio.mp3 --languages es
@@ -72,7 +77,7 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 1. **video**: Downloads media from URL (HLS or direct) → `output/video.mp4`
 2. **audio**: Extracts audio track → `output/audio.mp3`
 3. **signature**: Generates Shazam signature for fingerprinting (macOS only)
-4. **transcribe**: The selected model turns the audio into `{source-language}.srt`
+4. **transcribe**: The selected audio-capable model turns the audio into `{source-language}.srt`
 5. **translate**: The selected model translates that file into each target language
 6. **dub** (opt-in): Text-to-speech speaks each `{language}.srt` into a timing-aligned `{language}.mp3`
 
@@ -84,18 +89,19 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 - `transcribe()` turns audio into subtitles; `translate()` turns those subtitles into other languages
 - Both run the same loop: ask the model, repair the answer, validate it, and ask again if it cannot be saved
 - Exhausting the attempts raises `SubtitleValidationError`; no partial file is written
-- `get_provider()` picks the provider module from the model name (`config.provider`)
+- `get_provider()` picks the explicitly selected provider module (`config.provider`), with model-name inference retained for compatibility
 
-**intelligence/gemini.py** and **intelligence/openai.py**: Provider modules
-- Each exposes the same surface: `accepts_audio()`, `prepare_audio()`, `generate(system_instruction, text, with_audio)`, and `speak(text, language)` returning WAV bytes
+**intelligence/gemini.py**, **intelligence/openai.py**, **intelligence/anthropic.py**, and **intelligence/openrouter.py**: Provider modules
+- Each exposes the same surface: `accepts_audio()`, `prepare_audio()`, `generate(system_instruction, text, with_audio)`, and `speak(text, language)` returning audio bytes when TTS is available
 - Prompting and validation live in pipeline.py; the providers only talk to their API and retry transient failures
-- Provider selection is by model name: `gpt-*` (and other OpenAI prefixes) → OpenAI with `OPENAI_API_KEY`, everything else → Gemini with `GEMINI_API_KEY`
+- Provider selection is explicit via `--provider google|anthropic|openai|openrouter`; omitted selection infers OpenAI from `gpt-*`, Anthropic from `claude-*`, and Gemini otherwise. Each direct provider uses its matching key field; OpenRouter uses only `OPENROUTER_API_KEY` and its dashboard-managed BYOK configuration
 - OpenAI text models (gpt-5.6-*) cannot hear audio: transcription is routed to `whisper-1` on the transcription API, which answers in SRT (override with `--audio-model`; `gpt-audio-*` chat models are also accepted), while the selected model translates text-only; Gemini models hear audio natively
 - OpenAI audio is inlined as base64; files over 15 MB are re-encoded to mono 32 kbit/s MP3 first, which fits about an hour of speech under the 20 MB request cap. Gemini uploads the file once and caches the handle
-- Both providers tally per-model token/character counts in a module-level `usage` dict for cost accounting
+- OpenRouter uses the official Python SDK for async chat, segment-timestamped STT, and TTS; native Anthropic is text-only, so audio work should use an audio-capable provider/model
+- Providers tally per-model token/character counts in a module-level `usage` dict for cost accounting
 
 **media/dubber.py**: Text-to-speech dubbing of generated subtitles
-- Speaks each cue with the provider's TTS model (defaults: `gpt-4o-mini-tts` / `gemini-2.5-flash-preview-tts`, overridable with `--tts-model` / `--tts-voice`)
+- Speaks each cue with the selected provider's TTS model (defaults: `gpt-4o-mini-tts` / `gemini-2.5-flash-preview-tts` / OpenRouter's routed speech model, overridable with `--tts-model` / `--tts-voice`; native Anthropic has no TTS)
 - Places each cue at its start time over silence; speech longer than its slot is sped up with ffmpeg `atempo` (capped at 2x), and overruns push later cues instead of overlapping
 - `[sound effects]` and `(stage directions)` are not spoken; the output MP3 matches the original recording's length
 - Timing decisions (`cue_slots`, `plan_gaps`, `atempo_filter`, `speakable_text`) are pure functions tested without ffmpeg or an API key
@@ -141,7 +147,7 @@ The tool operates as a multi-stage pipeline controlled by the `--tasks` paramete
 
 **Config-Based Architecture**: All functions use the global config object instead of parameters. Functions like `download_from_url()`, `video_to_audio()`, `transcribe()`, and `translate()` take no parameters and get values from `config`.
 
-**Model Integration**: The selected model produces the subtitles directly from audio, and translates them from the source subtitle file plus the audio. Every answer passes through repair and validation before being written, because models get the words right far more reliably than the SRT container. The provider (Gemini or OpenAI) is inferred from the model name; both go through the same pipeline.
+**Model Integration**: An audio-capable selected model produces the subtitles directly from audio, and the selected model translates them from the source subtitle file plus the audio when supported. Every answer passes through repair and validation before being written, because models get the words right far more reliably than the SRT container. Provider selection is explicit, with model-name inference retained for compatibility; all providers go through the same pipeline.
 
 ## Project Structure
 
@@ -152,8 +158,10 @@ src/sub_tools/
 ├── arguments/           # CLI parsing
 ├── intelligence/        # Transcription and translation
 │   ├── pipeline.py      # Provider-agnostic prompts + repair/validate loop
-│   ├── gemini.py        # Gemini provider (generate + TTS)
-│   └── openai.py    # OpenAI provider (generate + TTS)
+│   ├── gemini.py        # Google/Gemini provider (generate + TTS)
+│   ├── openai.py        # OpenAI provider (generate + TTS)
+│   ├── anthropic.py     # Anthropic text provider
+│   └── openrouter.py    # OpenRouter SDK provider (chat, STT, TTS)
 ├── subtitles/           # SRT repair and validation
 ├── media/               # FFmpeg operations (video/audio conversion, dubbing)
 └── system/              # Console, directory, file utilities
@@ -163,6 +171,8 @@ src/sub_tools/
 
 - **google-genai**: Google Gemini API for transcription, translation, and TTS
 - **openai**: OpenAI API for transcription, translation, and TTS (used for gpt-* models)
+- **anthropic**: Anthropic Messages API for text-only subtitle translation
+- **openrouter**: OpenRouter's unified model, STT, and TTS SDK
 - **rich**: Terminal UI and progress bars
 - **ffmpeg** (system dependency): Video/audio conversion and dub assembly
 - **pycountry**: Language code handling
@@ -173,7 +183,7 @@ Test coverage focuses on the parts that decide whether output ships:
 - `test_repair.py`: every malformed shape a model actually returned
 - `test_validator.py`: what must be rejected, including files a lenient parser accepts
 - `test_dubber.py`: dub timing decisions (slots, gaps, tempo, speakable text)
-- `test_config.py`: provider and API-key selection from the model name
+- `test_config.py`: provider and API-key selection
 - `test_directory.py`: File path handling
 
 No integration tests for transcription (would require an API key and real audio).

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+ARG PYTHON_VERSION=3.13
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim
+
+# The test container supplies the system tools that the repository's media
+# integration tests need. The project and its Python dependencies are still
+# installed by the test workflow from the checked-out revision.
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes \
+        ca-certificates \
+        ffmpeg \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# The uv base image has uv as its entrypoint. GitHub Actions needs to run the
+# workflow commands directly inside the container instead.
+ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A toolkit for multilingual subtitles. A model transcribes the audio and translates the result; every answer is repaired and checked before it is accepted. Gemini 3.7 Flash is the primary model; OpenAI models such as GPT-5.6 Luna are supported as a lower-cost alternative.
+A toolkit for multilingual subtitles. A selected model transcribes the audio and translates the result; every answer is repaired and checked before it is accepted. Google Gemini is the default, with direct Anthropic and OpenAI APIs plus OpenRouter's model catalog available from the same pipeline.
 
 ## ✨ Features
 
-- 🎯 Transcription straight from audio to SRT, with Gemini or an OpenAI model
+- 🎯 Transcription straight from audio to SRT, with Google, OpenAI, or OpenRouter audio models
 - 🧰 Automatic repair of malformed model output, with a retry when repair cannot save it
 - ✅ Strict validation that refuses to ship a broken subtitle file
 - 🌍 Multilingual translation that preserves the source timings
@@ -65,7 +65,17 @@ sub-tools -i https://example.com/video.mp4 --languages en --model gemini-3.6-fla
 
 # Use an OpenAI model instead of Gemini (reads OPENAI_API_KEY)
 export OPENAI_API_KEY={your_api_key}
-sub-tools -i https://example.com/video.mp4 --languages en es --model gpt-5.6-luna
+sub-tools -i https://example.com/video.mp4 --languages en es --provider openai --model gpt-5.6-luna
+
+# Use an Anthropic model for text-only translation
+export ANTHROPIC_API_KEY={your_api_key}
+sub-tools --tasks translate --audio-file audio.mp3 --languages es --provider anthropic --model claude-sonnet-4-20250514
+
+# Use any OpenRouter model, including a separate audio model for transcription
+export OPENROUTER_API_KEY={your_api_key}
+sub-tools --tasks transcribe translate --audio-file audio.mp3 --languages es \
+  --provider openrouter --model anthropic/claude-sonnet-4 \
+  --audio-model google/gemini-2.5-flash
 
 # Dub: speak the translated subtitles into es.mp3 and fr.mp3
 sub-tools --tasks transcribe translate dub --audio-file audio.mp3 --languages es fr
@@ -76,18 +86,37 @@ sub-tools -i https://example.com/video.mp4 --languages en --output my-subtitles
 
 ### Choosing a provider
 
-The provider follows from the model name: `gpt-*` models call the OpenAI API with
-`OPENAI_API_KEY` (or `--openai-api-key`), everything else calls the Gemini API with
-`GEMINI_API_KEY` (or `--gemini-api-key`). The same repair and validation loop runs
-either way.
+Use `--provider` to choose `google`, `anthropic`, `openai`, or `openrouter`, and
+`--model` to choose the model identifier. If `--provider` is omitted, the tool
+infers OpenAI from `gpt-*` names, Anthropic from `claude-*` names, and Google
+otherwise. Set the key for
+the selected direct provider with its matching option or environment variable:
 
-OpenAI text models such as `gpt-5.6-luna` cannot hear audio, so transcription is
-routed to an audio-capable model (`whisper-1` on the transcription API by default;
-override with `--audio-model`, which also accepts `gpt-audio-*` chat models) while
-the selected model handles translation text-only. Audio
-sent to OpenAI is inlined into the request; files over 15 MB are automatically
-re-encoded to mono 32 kbit/s MP3, which fits roughly an hour of speech under the
-20 MB request cap.
+| Provider | CLI option | Environment variable |
+| --- | --- | --- |
+| Google/Gemini | `--gemini-api-key` | `GEMINI_API_KEY` |
+| OpenAI | `--openai-api-key` | `OPENAI_API_KEY` |
+| Anthropic | `--anthropic-api-key` | `ANTHROPIC_API_KEY` |
+| OpenRouter | `--openrouter-api-key` | `OPENROUTER_API_KEY` |
+
+OpenRouter uses one OpenRouter key for all routed models. If you enable
+OpenRouter's [BYOK](https://openrouter.ai/docs/guides/overview/multimodal/stt#byok-bring-your-own-key),
+configure upstream provider keys in OpenRouter; they are not copied into this
+tool or sent as per-request credentials.
+
+The same repair and validation loop runs for every provider.
+
+Text-only models can use `--audio-model` for transcription while the selected
+model handles translation text-only. OpenAI defaults to `whisper-1`; OpenRouter
+defaults to an audio-capable Gemini model and also supports dedicated STT models
+such as `openai/whisper-large-v3` when they return segment timestamps. Browse
+[OpenRouter's model catalog](https://openrouter.ai/models) for current audio and
+transcription models.
+
+Native Anthropic models are text-only: use them for translation when a source SRT
+already exists, or select the same Claude model through OpenRouter when audio
+input is required. OpenRouter's [official Python SDK](https://openrouter.ai/docs/client-sdks/python/overview)
+handles chat, STT, TTS, and its retry/routing behavior.
 
 ### Pipeline Tasks
 
@@ -104,9 +133,10 @@ By default, all tasks except `dub` run. You can customize which tasks to run wit
 
 ### Dubbing
 
-Each subtitle cue is spoken by the provider's text-to-speech model (OpenAI:
-`gpt-4o-mini-tts`, Gemini: `gemini-2.5-flash-preview-tts`; override with
-`--tts-model` and `--tts-voice`) and placed at the cue's start time over silence,
+Each subtitle cue is spoken by the selected provider's text-to-speech model (OpenAI:
+`gpt-4o-mini-tts`, Gemini: `gemini-2.5-flash-preview-tts`, OpenRouter: a routed
+speech model; native Anthropic has no TTS; override with `--tts-model` and
+`--tts-voice`) and placed at the cue's start time over silence,
 producing an MP3 the same length as the original recording. Speech that runs longer
 than the original speaker took is sped up (at most 2×) rather than talking over the
 next cue, and `[sound effects]` are not spoken. The dub uses the same provider as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,16 @@
 [project]
 name = "sub-tools"
 version = "0.9.2"
-description = "A robust Python toolkit powered by Google's Gemini API for converting video content into accurate, multilingual subtitles."
+description = "A robust Python toolkit for converting video content into accurate, multilingual subtitles with configurable AI providers."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "audioop-lts>=0.2.1; python_version >= '3.13'",
+    "anthropic>=0.52.0",
     "google-api-core>=2.28.1",
     "google-genai>=1.52.0",
     "openai>=1.68.0",
+    "openrouter>=1.0.0",
     "pycountry>=24.6.1",
     "pytest>=9.0.1",
     "pytest-asyncio>=0.23.5",

--- a/src/sub_tools/arguments/parser.py
+++ b/src/sub_tools/arguments/parser.py
@@ -2,7 +2,7 @@ import argparse
 from argparse import ArgumentParser, Namespace
 from importlib.metadata import version
 
-from ..config import apply_namespace, config
+from ..config import SUPPORTED_PROVIDERS, apply_namespace, config
 from .env_default import EnvDefault
 
 
@@ -95,10 +95,12 @@ def build_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--gemini-api-key",
+        "--google-api-key",
+        dest="gemini_api_key",
         action=EnvDefault,
         env_name="GEMINI_API_KEY",
         required=False,
-        help="Gemini API Key. If not provided, the script tries to use the GEMINI_API_KEY environment variable.",
+        help="Google/Gemini API key. Falls back to the GEMINI_API_KEY environment variable.",
     )
 
     parser.add_argument(
@@ -106,7 +108,33 @@ def build_parser() -> ArgumentParser:
         action=EnvDefault,
         env_name="OPENAI_API_KEY",
         required=False,
-        help="OpenAI API Key, used when an OpenAI model is selected. If not provided, the script tries to use the OPENAI_API_KEY environment variable.",
+        help="OpenAI API key. Falls back to the OPENAI_API_KEY environment variable.",
+    )
+
+    parser.add_argument(
+        "--anthropic-api-key",
+        action=EnvDefault,
+        env_name="ANTHROPIC_API_KEY",
+        required=False,
+        help="Anthropic API key. Falls back to the ANTHROPIC_API_KEY environment variable.",
+    )
+
+    parser.add_argument(
+        "--openrouter-api-key",
+        action=EnvDefault,
+        env_name="OPENROUTER_API_KEY",
+        required=False,
+        help="OpenRouter API key. Falls back to the OPENROUTER_API_KEY environment variable.",
+    )
+
+    parser.add_argument(
+        "--provider",
+        choices=SUPPORTED_PROVIDERS,
+        default=None,
+        help=(
+            "Model provider (default: inferred from the model). Choose google, anthropic, "
+            "openai, or openrouter; gemini is kept as a compatibility alias for google."
+        ),
     )
 
     parser.add_argument(
@@ -116,7 +144,8 @@ def build_parser() -> ArgumentParser:
         default=config.model,
         help=(
             "Model for transcription and translation (default: %(default)s). "
-            "Gemini models use the Gemini API; OpenAI models such as gpt-5.6-luna use the OpenAI API."
+            "Use the model identifier from the selected provider, including an OpenRouter "
+            "model slug such as google/gemini-2.5-flash."
         ),
     )
 
@@ -124,10 +153,9 @@ def build_parser() -> ArgumentParser:
         "--audio-model",
         default=config.audio_model,
         help=(
-            "Model that listens to the audio when the main model cannot. OpenAI text models "
-            "such as gpt-5.6-luna transcribe through this model (default: whisper-1 via the "
-            "transcription API; gpt-audio-* models are also accepted); Gemini models hear "
-            "audio natively and ignore it."
+            "Audio-capable model used for transcription when the main model cannot hear audio. "
+            "The identifier is interpreted by the selected provider (for example, "
+            "whisper-1 for OpenAI or google/gemini-2.5-flash for OpenRouter)."
         ),
     )
 

--- a/src/sub_tools/config.py
+++ b/src/sub_tools/config.py
@@ -5,11 +5,35 @@ Configuration for sub-tools.
 from dataclasses import dataclass, field, fields
 from typing import Any
 
-
 DEFAULT_MODEL = "gemini-3.7-flash"
 
 # Prefixes that identify an OpenAI model name, e.g. gpt-5.6-luna.
 OPENAI_MODEL_PREFIXES = ("gpt", "chatgpt", "o1", "o3", "o4")
+
+SUPPORTED_PROVIDERS = ("google", "gemini", "anthropic", "openai", "openrouter")
+
+
+def normalize_provider(provider: str) -> str:
+    """Return a supported provider name, preserving ``gemini`` for compatibility."""
+    value = provider.strip().lower()
+    if value not in SUPPORTED_PROVIDERS:
+        supported = ", ".join(SUPPORTED_PROVIDERS)
+        raise ValueError(
+            f"Unsupported provider {provider!r}; choose one of: {supported}"
+        )
+    return value
+
+
+def infer_provider(model: str) -> str:
+    """Infer a provider for callers that do not explicitly select one."""
+    name = model.strip().lower()
+    if name.startswith(OPENAI_MODEL_PREFIXES):
+        return "openai"
+    if name.startswith(("claude", "anthropic")):
+        return "anthropic"
+    if name.startswith("openrouter"):
+        return "openrouter"
+    return "gemini"
 
 
 @dataclass
@@ -41,11 +65,16 @@ class Config:
 
     # Model / provider
     model: str = DEFAULT_MODEL
+    provider: str | None = None
     gemini_api_key: str | None = None
     openai_api_key: str | None = None
+    anthropic_api_key: str | None = None
+    openrouter_api_key: str | None = None
     audio_model: str | None = None  # Provider default is used when unset
     tts_model: str | None = None  # Provider default is used when unset
     tts_voice: str | None = None  # Provider default is used when unset
+
+    _provider_explicit: bool = field(init=False, repr=False, default=False)
 
     # Validation
     max_valid_duration: int = (
@@ -61,24 +90,51 @@ class Config:
         0.02  # Share of source subtitles a translation may drop before it is rejected
     )
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "provider" and hasattr(self, "_provider_explicit"):
+            if value is not None:
+                value = normalize_provider(value)
+            object.__setattr__(self, "_provider_explicit", value is not None)
+        if name == "model" and hasattr(self, "_provider_explicit"):
+            object.__setattr__(self, name, value)
+            if not self._provider_explicit:
+                object.__setattr__(self, "provider", infer_provider(value))
+            return
+        object.__setattr__(self, name, value)
+
+    def __post_init__(self) -> None:
+        self.set_provider(self.provider, explicit=self.provider is not None)
+
+    def set_provider(self, provider: str | None, *, explicit: bool = True) -> None:
+        """Select a provider, or infer it from the model when ``None`` is given."""
+        if provider is None:
+            value = infer_provider(self.model)
+            explicit = False
+        else:
+            value = normalize_provider(provider)
+        object.__setattr__(self, "provider", value)
+        object.__setattr__(self, "_provider_explicit", explicit)
+
     @property
-    def provider(self) -> str:
-        """
-        The API provider implied by the model name: "openai" or "gemini".
-        """
-        name = self.model.lower()
-        if name.startswith(OPENAI_MODEL_PREFIXES):
-            return "openai"
-        return "gemini"
+    def resolved_provider(self) -> str:
+        """Return the provider currently selected for the configured model."""
+        if not self._provider_explicit:
+            return infer_provider(self.model)
+        return self.provider  # type: ignore[return-value]
 
     @property
     def api_key(self) -> str | None:
         """
         The API key for the selected provider.
         """
-        if self.provider == "openai":
-            return self.openai_api_key
-        return self.gemini_api_key
+        keys = {
+            "google": self.gemini_api_key,
+            "gemini": self.gemini_api_key,
+            "openai": self.openai_api_key,
+            "anthropic": self.anthropic_api_key,
+            "openrouter": self.openrouter_api_key,
+        }
+        return keys[self.resolved_provider]
 
 
 # Global config instance
@@ -90,6 +146,11 @@ def apply_namespace(source: Any) -> Config:
     Copy matching attributes from an argparse.Namespace-like object into config.
     """
     for field_def in fields(Config):
+        if field_def.name.startswith("_") or field_def.name == "provider":
+            continue
         if hasattr(source, field_def.name):
             setattr(config, field_def.name, getattr(source, field_def.name))
+
+    requested_provider = getattr(source, "provider", None)
+    config.set_provider(requested_provider, explicit=requested_provider is not None)
     return config

--- a/src/sub_tools/intelligence/anthropic.py
+++ b/src/sub_tools/intelligence/anthropic.py
@@ -1,0 +1,110 @@
+"""
+Anthropic provider for text generation.
+
+Claude's Messages API is useful for translation and other text-only subtitle
+work, but it does not accept audio input or provide text-to-speech. Users who
+want Claude's reasoning with audio should select an equivalent Claude model
+through OpenRouter instead.
+"""
+
+import asyncio
+
+import anthropic
+from anthropic import AsyncAnthropic
+
+from ..config import config
+from .retry import backoff
+
+MAX_OUTPUT_TOKENS = 16_384
+
+usage: dict[str, dict] = {}
+
+
+def accepts_audio() -> bool:
+    """Anthropic's native Messages API is text/image input, not audio input."""
+    return False
+
+
+def can_transcribe_audio() -> bool:
+    """Anthropic cannot transcribe audio through its native API."""
+    return False
+
+
+def prepare_audio() -> None:
+    """Keep the provider interface uniform; no audio upload is needed."""
+    return
+
+
+async def generate(
+    system_instruction: str,
+    text: str | None = None,
+    with_audio: bool = True,
+) -> str | None:
+    """Ask Claude for one text-only subtitle response."""
+    if with_audio:
+        raise RuntimeError(
+            "Anthropic models do not accept audio input; use an audio-capable "
+            "provider for transcription."
+        )
+
+    prompt = text or ""
+    for attempt in range(max(1, config.retry)):
+        try:
+            async with AsyncAnthropic(api_key=config.api_key) as client:
+                response = await client.messages.create(
+                    model=config.model,
+                    max_tokens=MAX_OUTPUT_TOKENS,
+                    system=system_instruction,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+            _record_usage(response)
+            return "".join(
+                block.text
+                for block in response.content
+                if getattr(block, "type", None) == "text"
+            )
+        except _RETRYABLE_ERRORS as error:
+            if attempt < config.retry - 1:
+                await asyncio.sleep(backoff(attempt))
+                continue
+            raise error
+
+    return None
+
+
+async def speak(text: str, language: str) -> bytes:
+    """Anthropic has no native text-to-speech endpoint."""
+    raise RuntimeError(
+        "Anthropic does not provide text-to-speech through its API; select a "
+        "provider with a TTS model for the dub task."
+    )
+
+
+def _bucket(model: str) -> dict:
+    return usage.setdefault(
+        model,
+        {
+            "requests": 0,
+            "input_tokens": 0,
+            "audio_input_tokens": 0,
+            "output_tokens": 0,
+            "tts_characters": 0,
+        },
+    )
+
+
+def _record_usage(response) -> None:
+    bucket = _bucket(config.model)
+    bucket["requests"] += 1
+    response_usage = getattr(response, "usage", None)
+    if response_usage:
+        bucket["input_tokens"] += getattr(response_usage, "input_tokens", 0) or 0
+        bucket["output_tokens"] += getattr(response_usage, "output_tokens", 0) or 0
+
+
+_RETRYABLE_ERRORS = (
+    anthropic.RateLimitError,
+    anthropic.InternalServerError,
+    anthropic.APIConnectionError,
+    anthropic.APITimeoutError,
+)

--- a/src/sub_tools/intelligence/gemini.py
+++ b/src/sub_tools/intelligence/gemini.py
@@ -37,13 +37,18 @@ def accepts_audio() -> bool:
     return True
 
 
+def can_transcribe_audio() -> bool:
+    """Gemini generation models accept audio input natively."""
+    return True
+
+
 def prepare_audio() -> types.File:
     """
     Upload the configured audio file once and reuse it across requests.
     """
     path = config.audio_file
     if path not in _uploaded_files:
-        client = genai.Client(api_key=config.gemini_api_key)
+        client = genai.Client(api_key=config.api_key)
         _uploaded_files[path] = client.files.upload(file=path)
     return _uploaded_files[path]
 
@@ -56,7 +61,7 @@ async def generate(
     """
     Ask Gemini once for subtitles, retrying only transient server-side failures.
     """
-    client = genai.Client(api_key=config.gemini_api_key)
+    client = genai.Client(api_key=config.api_key)
 
     parts = [prepare_audio()] if with_audio else []
     if text:
@@ -103,7 +108,7 @@ async def speak(text: str, language: str) -> bytes:
     """
     Turn one piece of text into speech, returned as WAV bytes.
     """
-    client = genai.Client(api_key=config.gemini_api_key)
+    client = genai.Client(api_key=config.api_key)
 
     voice = config.tts_voice or DEFAULT_TTS_VOICE
     response = await client.aio.models.generate_content(

--- a/src/sub_tools/intelligence/openai.py
+++ b/src/sub_tools/intelligence/openai.py
@@ -30,7 +30,13 @@ DEFAULT_TTS_MODEL = "gpt-4o-mini-tts"
 DEFAULT_TTS_VOICE = "alloy"
 
 # Model families that accept audio input in chat; everything else is text-only.
-AUDIO_MODEL_PREFIXES = ("gpt-audio", "gpt-4o-audio", "gpt-realtime")
+AUDIO_MODEL_PREFIXES = (
+    "gpt-audio",
+    "gpt-4o-audio",
+    "gpt-4o-mini-audio",
+    "gpt-realtime",
+    "gpt-4o-mini-realtime",
+)
 
 # Model families served by the dedicated transcription endpoint, which returns
 # SRT directly. Chat audio models (gpt-audio-*) can follow instructions but
@@ -61,6 +67,11 @@ def accepts_audio() -> bool:
     return config.model.lower().startswith(AUDIO_MODEL_PREFIXES)
 
 
+def can_transcribe_audio() -> bool:
+    """OpenAI has either chat-audio or dedicated transcription routes."""
+    return True
+
+
 def uses_transcription_api(model: str) -> bool:
     """
     Whether a model is served by the dedicated transcription endpoint.
@@ -73,6 +84,8 @@ def generation_model(with_audio: bool) -> str:
     The model a request should go to: audio requests from a text-only model
     are routed to the audio model.
     """
+    if with_audio and uses_transcription_api(config.model):
+        return config.model
     if with_audio and not accepts_audio():
         return config.audio_model or DEFAULT_AUDIO_MODEL
     return config.model
@@ -171,7 +184,7 @@ async def generate(
 
     kwargs = {"modalities": ["text"]} if with_audio else {}
 
-    async with AsyncOpenAI(api_key=config.openai_api_key) as client:
+    async with AsyncOpenAI(api_key=config.api_key) as client:
         for attempt in range(config.retry):
             try:
                 response = await client.chat.completions.create(
@@ -209,7 +222,7 @@ async def _transcribe_via_api(model: str) -> Optional[str]:
 
     send_path, _ = _send_file()
 
-    async with AsyncOpenAI(api_key=config.openai_api_key) as client:
+    async with AsyncOpenAI(api_key=config.api_key) as client:
         for attempt in range(config.retry):
             try:
                 with open(send_path, "rb") as f:
@@ -243,7 +256,7 @@ async def speak(text: str, language: str) -> bytes:
     """
     model = config.tts_model or DEFAULT_TTS_MODEL
 
-    async with AsyncOpenAI(api_key=config.openai_api_key) as client:
+    async with AsyncOpenAI(api_key=config.api_key) as client:
         response = await client.audio.speech.create(
             model=model,
             voice=config.tts_voice or DEFAULT_TTS_VOICE,

--- a/src/sub_tools/intelligence/openrouter.py
+++ b/src/sub_tools/intelligence/openrouter.py
@@ -1,0 +1,313 @@
+"""
+OpenRouter provider.
+
+OpenRouter's official Python SDK exposes async chat, speech-to-text, and
+text-to-speech methods. Audio-capable chat models can return timestamped SRT
+directly; dedicated speech-to-text models are also supported when their response
+includes timestamped segments.
+"""
+
+import base64
+import os
+import subprocess
+import tempfile
+from typing import Any
+
+from openrouter import OpenRouter
+
+from ..config import config
+from ..system.console import info
+
+DEFAULT_AUDIO_MODEL = "google/gemini-2.5-flash"
+DEFAULT_TTS_MODEL = "openai/gpt-4o-mini-tts"
+DEFAULT_TTS_VOICE = "alloy"
+
+# These are hints rather than a closed model registry. OpenRouter adds models
+# frequently, and --audio-model is available for a model with a new name.
+AUDIO_MODEL_HINTS = (
+    "audio",
+    "gemini",
+    "gpt-4o",
+    "omni",
+    "qwen2-audio",
+    "qwen3-omni",
+    "voxtral",
+    "realtime",
+)
+TRANSCRIPTION_MODEL_HINTS = (
+    "whisper",
+    "transcrib",
+    "parakeet",
+    "moonshine",
+    "canary",
+    "speech-to-text",
+    "stt",
+)
+
+# Keep requests reasonably sized for providers behind OpenRouter. Audio input
+# is base64-encoded, so a 15 MB source remains a safe size for most contexts.
+MAX_FILE_BYTES = 15 * 1024 * 1024
+COMPRESS_BITRATE = "32k"
+COMPRESS_SAMPLE_RATE = 16_000
+
+usage: dict[str, dict] = {}
+_send_files: dict[str, tuple[str, str]] = {}
+_audio_cache: dict[str, tuple[str, str]] = {}
+
+
+def accepts_audio() -> bool:
+    """Whether the selected model is likely to accept chat audio input."""
+    model = _model_leaf(config.model)
+    return _has_hint(model, AUDIO_MODEL_HINTS) and not uses_transcription_api(
+        config.model
+    )
+
+
+def can_transcribe_audio() -> bool:
+    """OpenRouter provides chat-audio and dedicated speech-to-text routes."""
+    return True
+
+
+def uses_transcription_api(model: str) -> bool:
+    """Whether a model looks like a dedicated OpenRouter STT model."""
+    return _has_hint(_model_leaf(model), TRANSCRIPTION_MODEL_HINTS)
+
+
+def generation_model(with_audio: bool) -> str:
+    """Choose the configured model or an audio model for an audio request."""
+    if with_audio and uses_transcription_api(config.model):
+        return config.model
+    if with_audio and not accepts_audio():
+        return config.audio_model or DEFAULT_AUDIO_MODEL
+    return config.model
+
+
+def prepare_audio() -> tuple[str, str]:
+    """Read and base64-encode the configured audio file once."""
+    path = config.audio_file
+    if path not in _audio_cache:
+        send_path, extension = _send_file()
+        with open(send_path, "rb") as audio:
+            data = base64.b64encode(audio.read()).decode("ascii")
+        _audio_cache[path] = (data, extension)
+    return _audio_cache[path]
+
+
+async def generate(
+    system_instruction: str,
+    text: str | None = None,
+    with_audio: bool = True,
+) -> str | None:
+    """Ask one OpenRouter model for subtitles using the SDK retry policy."""
+    model = generation_model(with_audio)
+    if with_audio and model != config.model:
+        info(f"{config.model} cannot hear audio; listening with {model}")
+
+    if with_audio and uses_transcription_api(model):
+        return await _transcribe_via_api(model)
+
+    content: str | list[dict[str, Any]]
+    if with_audio:
+        data, audio_format = prepare_audio()
+        content = [
+            {
+                "type": "input_audio",
+                "input_audio": {"data": data, "format_": audio_format},
+            }
+        ]
+        if text:
+            content.append({"type": "text", "text": text})
+    else:
+        content = text or ""
+
+    async with _client() as client:
+        response = await client.chat.send_async(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_instruction},
+                {"role": "user", "content": content},
+            ],
+            stream=False,
+        )
+    _record_usage(model, response.usage)
+    return _message_text(response.choices[0].message)
+
+
+async def _transcribe_via_api(model: str) -> str | None:
+    """Use OpenRouter's SDK STT endpoint and preserve returned segments."""
+    send_path, _ = _send_file()
+    async with _client() as client:
+        with open(send_path, "rb") as audio:
+            result = await client.stt.create_transcription_multipart_async(
+                file={"file_name": os.path.basename(send_path), "content": audio},
+                model=model,
+                language=config.source_language,
+                response_format="verbose_json",
+                timestamp_granularities=["segment"],
+            )
+
+    _record_transcription_usage(model, result.usage)
+    if result.segments:
+        return _segments_to_srt(result.segments)
+    # Non-OpenAI-compatible STT providers may return text only. Returning it
+    # lets the shared validation loop explain that timestamped SRT is required
+    # instead of silently inventing timings.
+    return result.text
+
+
+async def speak(text: str, language: str) -> bytes:
+    """Generate speech through OpenRouter's TTS endpoint."""
+    model = config.tts_model or DEFAULT_TTS_MODEL
+    async with _client() as client:
+        response = await client.tts.create_speech_async(
+            model=model,
+            input=text,
+            voice=config.tts_voice or DEFAULT_TTS_VOICE,
+            response_format="mp3",
+        )
+        await response.aread()
+        data = response.content
+
+    bucket = _bucket(model)
+    bucket["requests"] += 1
+    bucket["tts_characters"] += len(text)
+    return data
+
+
+def _client() -> OpenRouter:
+    return OpenRouter(
+        api_key=config.api_key,
+        http_referer="https://github.com/dohyeondk/sub-tools",
+        x_open_router_title="sub-tools",
+    )
+
+
+def _model_leaf(model: str) -> str:
+    return model.rsplit("/", 1)[-1].lower()
+
+
+def _has_hint(model: str, hints: tuple[str, ...]) -> bool:
+    return any(hint in model for hint in hints)
+
+
+def _send_file() -> tuple[str, str]:
+    path = config.audio_file
+    if path not in _send_files:
+        send_path, extension = path, _extension(path)
+        if os.path.getsize(path) > MAX_FILE_BYTES:
+            send_path = _compress(path)
+            extension = "mp3"
+            if os.path.getsize(send_path) > MAX_FILE_BYTES:
+                raise RuntimeError(
+                    f"{path} is still too large for OpenRouter audio input after "
+                    f"re-encoding at {COMPRESS_BITRATE}bit/s"
+                )
+        _send_files[path] = (send_path, extension)
+    return _send_files[path]
+
+
+def _extension(path: str) -> str:
+    return os.path.splitext(path)[1].lstrip(".").lower() or "mp3"
+
+
+def _compress(path: str) -> str:
+    fd, compressed = tempfile.mkstemp(suffix=".mp3")
+    os.close(fd)
+    cmd = [
+        "ffmpeg", "-y", "-i", path,
+        "-ac", "1", "-ar", str(COMPRESS_SAMPLE_RATE), "-b:a", COMPRESS_BITRATE,
+        compressed,
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as error:
+        stderr = error.stderr.decode() if getattr(error, "stderr", None) else str(error)
+        raise RuntimeError(
+            f"Failed to compress {path} for OpenRouter audio input: {stderr}"
+        )
+    return compressed
+
+
+def _message_text(message) -> str | None:
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+            elif isinstance(getattr(item, "text", None), str):
+                parts.append(item.text)
+        return "".join(parts) or None
+    return None
+
+
+def _segments_to_srt(segments: list[Any]) -> str:
+    cues = []
+    for segment in segments:
+        start_seconds = float(_field(segment, "start", 0))
+        end_seconds = float(_field(segment, "end", start_seconds))
+        start = _timestamp(start_seconds)
+        end = _timestamp(end_seconds)
+        text = str(_field(segment, "text", "")).strip()
+        if text:
+            cues.append(f"{len(cues) + 1}\n{start} --> {end}\n{text}\n")
+    return "\n".join(cues)
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _timestamp(seconds: float) -> str:
+    milliseconds = max(0, round(seconds * 1000))
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, milliseconds = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{milliseconds:03d}"
+
+
+def _bucket(model: str) -> dict:
+    return usage.setdefault(
+        model,
+        {
+            "requests": 0,
+            "input_tokens": 0,
+            "audio_input_tokens": 0,
+            "output_tokens": 0,
+            "tts_characters": 0,
+            "transcribe_seconds": 0,
+        },
+    )
+
+
+def _record_usage(model: str, response_usage) -> None:
+    if not response_usage:
+        return
+    bucket = _bucket(model)
+    bucket["requests"] += 1
+    bucket["input_tokens"] += getattr(response_usage, "prompt_tokens", 0) or getattr(
+        response_usage, "input_tokens", 0
+    ) or 0
+    bucket["output_tokens"] += (
+        getattr(response_usage, "completion_tokens", 0)
+        or getattr(response_usage, "output_tokens", 0)
+        or 0
+    )
+    details = getattr(response_usage, "prompt_tokens_details", None)
+    if details and getattr(details, "audio_tokens", None):
+        bucket["audio_input_tokens"] += details.audio_tokens
+
+
+def _record_transcription_usage(model: str, response_usage: Any) -> None:
+    bucket = _bucket(model)
+    bucket["requests"] += 1
+    if response_usage:
+        bucket["input_tokens"] += _field(response_usage, "input_tokens", 0) or 0
+        bucket["output_tokens"] += _field(response_usage, "output_tokens", 0) or 0
+        bucket["transcribe_seconds"] += _field(response_usage, "seconds", 0) or 0

--- a/src/sub_tools/intelligence/pipeline.py
+++ b/src/sub_tools/intelligence/pipeline.py
@@ -2,8 +2,8 @@
 Provider-agnostic transcription and translation.
 
 The prompts, the repair/validate loop, and the retry policy live here; the
-provider modules (gemini, openai) only know how to answer one request.
-Which provider is used follows from the model name in config.
+provider modules only know how to answer one request. The provider is selected
+explicitly in config, with model-name inference retained for compatibility.
 """
 
 import asyncio
@@ -24,16 +24,28 @@ from ..subtitles.validator import SubtitleValidationError, find_problems
 
 def get_provider() -> ModuleType:
     """
-    Return the provider module implied by the configured model name.
+    Return the configured provider module.
     """
-    if config.provider == "openai":
+    provider_name = config.resolved_provider
+
+    if provider_name == "openai":
         from . import openai
 
         return openai
+    if provider_name == "openrouter":
+        from . import openrouter
 
-    from . import gemini
+        return openrouter
+    if provider_name == "anthropic":
+        from . import anthropic
 
-    return gemini
+        return anthropic
+    if provider_name in ("google", "gemini"):
+        from . import gemini
+
+        return gemini
+
+    raise ValueError(f"Unsupported provider: {provider_name}")
 
 
 def transcribe() -> None:
@@ -47,6 +59,14 @@ def transcribe() -> None:
 
 
 async def _transcribe() -> None:
+    provider = get_provider()
+    if not getattr(provider, "can_transcribe_audio", lambda: True)():
+        raise RuntimeError(
+            "The Anthropic API does not accept audio input. Use an audio-capable "
+            "provider/model for transcribe, or run Anthropic for translate with an "
+            "existing source SRT."
+        )
+
     info(f"Transcribing with {config.model}...")
 
     language_code = config.source_language
@@ -74,7 +94,7 @@ async def _transcribe() -> None:
     Reply with the SRT text now.
     """
 
-    get_provider().prepare_audio()
+    provider.prepare_audio()
     await _generate_subtitles(
         output_file=f"{language_code}.srt",
         system_instruction=system_instruction,

--- a/src/sub_tools/main.py
+++ b/src/sub_tools/main.py
@@ -17,8 +17,15 @@ def main():
     def require_api_key() -> None:
         if not (config.api_key and config.api_key.strip()):
             parsed.func()
-            name = "OpenAI" if config.provider == "openai" else "Gemini"
-            raise Exception(f"No {name} API Key provided")
+            names = {
+                "google": "Google/Gemini",
+                "gemini": "Google/Gemini",
+                "openai": "OpenAI",
+                "anthropic": "Anthropic",
+                "openrouter": "OpenRouter",
+            }
+            name = names[config.resolved_provider]
+            raise Exception(f"No {name} API key provided")
 
     try:
         ensure_output_directory(config.output_directory)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,14 @@ class TestProviderInference:
     def test_case_is_ignored(self):
         assert Config(model="GPT-5.6-Luna").provider == "openai"
 
+    def test_anthropic_models_are_inferred(self):
+        assert Config(model="claude-sonnet-4").provider == "anthropic"
+
+    def test_explicit_provider_overrides_model_inference(self):
+        config = Config(provider="openrouter", model="claude-sonnet-4")
+        assert config.provider == "openrouter"
+        assert config.resolved_provider == "openrouter"
+
 
 class TestOpenAIAudioRouting:
     def test_text_models_route_audio_requests_to_the_audio_model(self, monkeypatch):
@@ -37,6 +45,10 @@ class TestOpenAIAudioRouting:
         assert provider.accepts_audio() is True
         assert provider.generation_model(with_audio=True) == "gpt-audio-1.5"
 
+        monkeypatch.setattr(config, "model", "gpt-4o-mini-audio-preview")
+        assert provider.accepts_audio() is True
+        assert provider.generation_model(with_audio=True) == "gpt-4o-mini-audio-preview"
+
     def test_audio_model_override_is_respected(self, monkeypatch):
         from sub_tools.config import config
         from sub_tools.intelligence import openai as provider
@@ -54,3 +66,17 @@ class TestApiKeySelection:
     def test_openai_key_is_used_for_openai_models(self):
         config = Config(model="gpt-5.6-luna", gemini_api_key="g", openai_api_key="o")
         assert config.api_key == "o"
+
+    def test_explicit_provider_selects_its_key(self):
+        config = Config(
+            provider="anthropic",
+            model="openai/gpt-5.6-luna",
+            gemini_api_key="g",
+            openai_api_key="o",
+            anthropic_api_key="a",
+            openrouter_api_key="r",
+        )
+        assert config.api_key == "a"
+
+        config.set_provider("openrouter")
+        assert config.api_key == "r"

--- a/tests/test_provider_selection.py
+++ b/tests/test_provider_selection.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from sub_tools.arguments.parser import build_parser
+from sub_tools.config import config
+from sub_tools.intelligence import openrouter
+from sub_tools.intelligence.pipeline import get_provider
+
+
+def test_cli_accepts_each_provider_and_key():
+    parser = build_parser()
+    parsed = parser.parse_args(
+        [
+            "--provider",
+            "openrouter",
+            "--model",
+            "anthropic/claude-sonnet-4",
+            "--openrouter-api-key",
+            "router-key",
+        ]
+    )
+
+    assert parsed.provider == "openrouter"
+    assert parsed.model == "anthropic/claude-sonnet-4"
+    assert parsed.openrouter_api_key == "router-key"
+
+
+def test_get_provider_uses_explicit_selection(monkeypatch):
+    monkeypatch.setattr(config, "model", "claude-sonnet-4")
+    monkeypatch.setattr(config, "provider", "openrouter")
+    monkeypatch.setattr(config, "_provider_explicit", True)
+    assert get_provider().__name__.endswith("openrouter")
+
+
+def test_openrouter_routes_audio_and_transcription_models(monkeypatch):
+    monkeypatch.setattr(config, "model", "anthropic/claude-sonnet-4")
+    monkeypatch.setattr(config, "audio_model", None)
+    assert openrouter.accepts_audio() is False
+    assert (
+        openrouter.generation_model(with_audio=True) == openrouter.DEFAULT_AUDIO_MODEL
+    )
+
+    monkeypatch.setattr(config, "model", "openai/whisper-large-v3")
+    assert openrouter.accepts_audio() is False
+    assert openrouter.uses_transcription_api(config.model) is True
+    assert openrouter.generation_model(with_audio=True) == config.model
+
+    monkeypatch.setattr(config, "model", "openai/gpt-4o")
+    assert openrouter.accepts_audio() is True
+
+
+def test_openrouter_segments_are_srt():
+    result = openrouter._segments_to_srt(
+        [SimpleNamespace(start=0.25, end=1.75, text="Hello")]
+    )
+    assert result == "1\n00:00:00,250 --> 00:00:01,750\nHello\n"

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.122.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/23/9987d70b74e3481d5bc5d2021d3e10fd5f60c1f7b54088ea86506d9b7f2b/anthropic-0.122.0.tar.gz", hash = "sha256:ffec56ae96657c8d19fa575ec96f140f380c353a07ab7d61b92eb18ee6536601", size = 1021535, upload-time = "2026-08-13T18:36:00.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/5b/f5c87e71097a9f89f1b414d1ef7ae8439051fae57d5e4ee90946082982b8/anthropic-0.122.0-py3-none-any.whl", hash = "sha256:45ec906452ffae6b5f7f0c53d01f50bfb7e4ce878d7ae8e4309d13171e557e67", size = 1041853, upload-time = "2026-08-13T18:36:01.831Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -216,6 +235,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -495,6 +523,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpath-python"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/18/4ca8742534a5993ff383f7602e325ce2d5d7cc93d72ac5e1cdedbea8a458/jsonpath_python-1.1.6.tar.gz", hash = "sha256:dded9932b4ec41fb8726e09c83afa4e6be618f938c2db287cc2a81723c639671", size = 88178, upload-time = "2026-05-07T01:26:34.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8a/1270a6803bd821cbfcdda387eaa13cb41a7b1f7b9bd145979b3bfb9d6cb7/jsonpath_python-1.1.6-py3-none-any.whl", hash = "sha256:a1c50afd8d3fbbaf47a4873bc890dcb3c15da96f5c020327977d844d8731a2d4", size = 14453, upload-time = "2026-05-07T01:26:33.306Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -715,6 +752,21 @@ wheels = [
 ]
 
 [[package]]
+name = "openrouter"
+version = "1.1.57"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "jsonpath-python" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/bb/a3118992283826311deae4e5407a7573396c5f27e7efacb93ae7cf04c841/openrouter-1.1.57.tar.gz", hash = "sha256:e1c335f46bddd98250577dfef0f2ccf6b44b8e03bd4015ca6797a246a2439dbf", size = 424571, upload-time = "2026-08-14T21:30:59.337Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/0c/dfcca9db446110b96d117f2a964e67a650b48d74739c3428a0572502e889/openrouter-1.1.57-py3-none-any.whl", hash = "sha256:e53be6f9faa271e39a94f0afe630e07aed28e37315ce5ddd9e9ddf952971ac86", size = 920164, upload-time = "2026-08-14T21:30:57.666Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -799,91 +851,135 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.4"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/7e/fb60e6fee04d0ef8f15e4e01ff187a196fa976eb0f0ab524af4599e5754c/pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06", size = 762094, upload-time = "2024-12-18T17:09:24.84Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/26/3e1bbe954fde7ee22a6e7d31582c642aad9e84ffe4b5fb61e63b87cd326f/pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d", size = 431765, upload-time = "2024-12-18T17:09:21.953Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443, upload-time = "2024-12-18T11:31:54.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938, upload-time = "2024-12-18T11:27:14.406Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684, upload-time = "2024-12-18T11:27:16.489Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169, upload-time = "2024-12-18T11:27:22.16Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227, upload-time = "2024-12-18T11:27:25.097Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695, upload-time = "2024-12-18T11:27:28.656Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662, upload-time = "2024-12-18T11:27:30.798Z" },
-    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370, upload-time = "2024-12-18T11:27:33.692Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813, upload-time = "2024-12-18T11:27:37.111Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287, upload-time = "2024-12-18T11:27:40.566Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414, upload-time = "2024-12-18T11:27:43.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301, upload-time = "2024-12-18T11:27:47.36Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685, upload-time = "2024-12-18T11:27:50.508Z" },
-    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876, upload-time = "2024-12-18T11:27:53.54Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421, upload-time = "2024-12-18T11:27:55.409Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998, upload-time = "2024-12-18T11:27:57.252Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167, upload-time = "2024-12-18T11:27:59.146Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071, upload-time = "2024-12-18T11:28:02.625Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244, upload-time = "2024-12-18T11:28:04.442Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470, upload-time = "2024-12-18T11:28:07.679Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291, upload-time = "2024-12-18T11:28:10.297Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613, upload-time = "2024-12-18T11:28:13.362Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355, upload-time = "2024-12-18T11:28:16.587Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661, upload-time = "2024-12-18T11:28:18.407Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261, upload-time = "2024-12-18T11:28:21.471Z" },
-    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361, upload-time = "2024-12-18T11:28:23.53Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484, upload-time = "2024-12-18T11:28:25.391Z" },
-    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102, upload-time = "2024-12-18T11:28:28.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127, upload-time = "2024-12-18T11:28:30.346Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340, upload-time = "2024-12-18T11:28:32.521Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900, upload-time = "2024-12-18T11:28:34.507Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177, upload-time = "2024-12-18T11:28:36.488Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046, upload-time = "2024-12-18T11:28:39.409Z" },
-    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386, upload-time = "2024-12-18T11:28:41.221Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060, upload-time = "2024-12-18T11:28:44.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870, upload-time = "2024-12-18T11:28:46.839Z" },
-    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822, upload-time = "2024-12-18T11:28:48.896Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364, upload-time = "2024-12-18T11:28:50.755Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303, upload-time = "2024-12-18T11:28:54.122Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064, upload-time = "2024-12-18T11:28:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046, upload-time = "2024-12-18T11:28:58.107Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092, upload-time = "2024-12-18T11:29:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709, upload-time = "2024-12-18T11:29:03.193Z" },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273, upload-time = "2024-12-18T11:29:05.306Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027, upload-time = "2024-12-18T11:29:07.294Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888, upload-time = "2024-12-18T11:29:09.249Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738, upload-time = "2024-12-18T11:29:11.23Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138, upload-time = "2024-12-18T11:29:16.396Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025, upload-time = "2024-12-18T11:29:20.25Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633, upload-time = "2024-12-18T11:29:23.877Z" },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404, upload-time = "2024-12-18T11:29:25.872Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130, upload-time = "2024-12-18T11:29:29.252Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946, upload-time = "2024-12-18T11:29:31.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387, upload-time = "2024-12-18T11:29:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453, upload-time = "2024-12-18T11:29:35.533Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186, upload-time = "2024-12-18T11:29:37.649Z" },
-    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159, upload-time = "2024-12-18T11:30:54.382Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331, upload-time = "2024-12-18T11:30:58.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467, upload-time = "2024-12-18T11:31:00.6Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797, upload-time = "2024-12-18T11:31:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839, upload-time = "2024-12-18T11:31:09.775Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861, upload-time = "2024-12-18T11:31:13.469Z" },
-    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582, upload-time = "2024-12-18T11:31:17.423Z" },
-    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985, upload-time = "2024-12-18T11:31:19.901Z" },
-    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715, upload-time = "2024-12-18T11:31:22.821Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
 ]
 
 [[package]]
@@ -1195,10 +1291,12 @@ name = "sub-tools"
 version = "0.9.2"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "google-api-core" },
     { name = "google-genai" },
     { name = "openai" },
+    { name = "openrouter" },
     { name = "pycountry" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1208,10 +1306,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.52.0" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.1" },
     { name = "google-api-core", specifier = ">=2.28.1" },
     { name = "google-genai", specifier = ">=1.52.0" },
     { name = "openai", specifier = ">=1.68.0" },
+    { name = "openrouter", specifier = ">=1.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.5" },
@@ -1319,6 +1419,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds explicit provider/model CLI selection for Google/Gemini, OpenAI, Anthropic, and OpenRouter with provider-specific API keys. Integrates the official OpenRouter SDK for chat, timestamped STT, and TTS, including audio-model routing and dashboard-managed BYOK, plus Anthropic text translation support, documentation, dependency updates, and tests. Tests: the focused suite passes with 76 tests; the full non-slow suite has 77 passing and 4 FFmpeg-dependent failures because FFmpeg is unavailable in the sandbox.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b7099382-3f4e-4868-b292-69c8f9634e84)
